### PR TITLE
BisPartition_t was missing SAFE, meaning User and System were using wrong key_source

### DIFF
--- a/fusee/fusee-secondary/src/key_derivation.c
+++ b/fusee/fusee-secondary/src/key_derivation.c
@@ -196,17 +196,15 @@ void derive_bis_key(void *dst, BisPartition_t partition_id, u32 target_firmware)
     
     static const u8 bis_kek_source[0x10] = {0x34, 0xC1, 0xA0, 0xC4, 0x82, 0x58, 0xF8, 0xB4, 0xFA, 0x9E, 0x5E, 0x6A, 0xDA, 0xFC, 0x7E, 0x4F};
 
-    const int key_source_idx = (partition_id > 2) ? 2 : partition_id;    
     switch (partition_id) {
         case BisPartition_Calibration:
-            fusee_generate_specific_aes_key(dst, key_source_for_bis[key_source_idx][0], false, target_firmware);
-            fusee_generate_specific_aes_key(dst + 0x10, key_source_for_bis[key_source_idx][1], false, target_firmware);
+            fusee_generate_specific_aes_key(dst, key_source_for_bis[partition_id][0], false, target_firmware);
+            fusee_generate_specific_aes_key(dst + 0x10, key_source_for_bis[partition_id][1], false, target_firmware);
             break;
         case BisPartition_Safe:
-        case BisPartition_User:
-        case BisPartition_System:
-            fusee_generate_personalized_aes_key_for_bis(dst, bis_kek_source, key_source_for_bis[key_source_idx][0], target_firmware);
-            fusee_generate_personalized_aes_key_for_bis(dst + 0x10, bis_kek_source, key_source_for_bis[key_source_idx][1], target_firmware);
+        case BisPartition_UserSystem:
+            fusee_generate_personalized_aes_key_for_bis(dst, bis_kek_source, key_source_for_bis[partition_id][0], target_firmware);
+            fusee_generate_personalized_aes_key_for_bis(dst + 0x10, bis_kek_source, key_source_for_bis[partition_id][1], target_firmware);
             break;
         default:
             generic_panic();

--- a/fusee/fusee-secondary/src/key_derivation.c
+++ b/fusee/fusee-secondary/src/key_derivation.c
@@ -195,16 +195,18 @@ void derive_bis_key(void *dst, BisPartition_t partition_id, u32 target_firmware)
     };
     
     static const u8 bis_kek_source[0x10] = {0x34, 0xC1, 0xA0, 0xC4, 0x82, 0x58, 0xF8, 0xB4, 0xFA, 0x9E, 0x5E, 0x6A, 0xDA, 0xFC, 0x7E, 0x4F};
-    
+	
+	const int key_source_idx = (partition_id > 2) ? 2 : partition_id;    
     switch (partition_id) {
         case BisPartition_Calibration:
-            fusee_generate_specific_aes_key(dst, key_source_for_bis[partition_id][0], false, target_firmware);
-            fusee_generate_specific_aes_key(dst + 0x10, key_source_for_bis[partition_id][1], false, target_firmware);
+            fusee_generate_specific_aes_key(dst, key_source_for_bis[key_source_idx][0], false, target_firmware);
+            fusee_generate_specific_aes_key(dst + 0x10, key_source_for_bis[key_source_idx][1], false, target_firmware);
             break;
+		case BisPartition_Safe:
         case BisPartition_User:
         case BisPartition_System:
-            fusee_generate_personalized_aes_key_for_bis(dst, bis_kek_source, key_source_for_bis[partition_id][0], target_firmware);
-            fusee_generate_personalized_aes_key_for_bis(dst + 0x10, bis_kek_source, key_source_for_bis[partition_id][1], target_firmware);
+            fusee_generate_personalized_aes_key_for_bis(dst, bis_kek_source, key_source_for_bis[key_source_idx][0], target_firmware);
+            fusee_generate_personalized_aes_key_for_bis(dst + 0x10, bis_kek_source, key_source_for_bis[key_source_idx][1], target_firmware);
             break;
         default:
             generic_panic();

--- a/fusee/fusee-secondary/src/key_derivation.c
+++ b/fusee/fusee-secondary/src/key_derivation.c
@@ -195,7 +195,6 @@ void derive_bis_key(void *dst, BisPartition_t partition_id, u32 target_firmware)
     };
     
     static const u8 bis_kek_source[0x10] = {0x34, 0xC1, 0xA0, 0xC4, 0x82, 0x58, 0xF8, 0xB4, 0xFA, 0x9E, 0x5E, 0x6A, 0xDA, 0xFC, 0x7E, 0x4F};
-
     switch (partition_id) {
         case BisPartition_Calibration:
             fusee_generate_specific_aes_key(dst, key_source_for_bis[partition_id][0], false, target_firmware);

--- a/fusee/fusee-secondary/src/key_derivation.c
+++ b/fusee/fusee-secondary/src/key_derivation.c
@@ -195,14 +195,14 @@ void derive_bis_key(void *dst, BisPartition_t partition_id, u32 target_firmware)
     };
     
     static const u8 bis_kek_source[0x10] = {0x34, 0xC1, 0xA0, 0xC4, 0x82, 0x58, 0xF8, 0xB4, 0xFA, 0x9E, 0x5E, 0x6A, 0xDA, 0xFC, 0x7E, 0x4F};
-	
-	const int key_source_idx = (partition_id > 2) ? 2 : partition_id;    
+
+    const int key_source_idx = (partition_id > 2) ? 2 : partition_id;    
     switch (partition_id) {
         case BisPartition_Calibration:
             fusee_generate_specific_aes_key(dst, key_source_for_bis[key_source_idx][0], false, target_firmware);
             fusee_generate_specific_aes_key(dst + 0x10, key_source_for_bis[key_source_idx][1], false, target_firmware);
             break;
-		case BisPartition_Safe:
+        case BisPartition_Safe:
         case BisPartition_User:
         case BisPartition_System:
             fusee_generate_personalized_aes_key_for_bis(dst, bis_kek_source, key_source_for_bis[key_source_idx][0], target_firmware);

--- a/fusee/fusee-secondary/src/key_derivation.h
+++ b/fusee/fusee-secondary/src/key_derivation.h
@@ -16,7 +16,7 @@
 
 typedef enum {
     BisPartition_Calibration = 0,
-	BisPartition_Safe = 1,
+    BisPartition_Safe = 1,
     BisPartition_User = 2,
     BisPartition_System = 3
 } BisPartition_t;

--- a/fusee/fusee-secondary/src/key_derivation.h
+++ b/fusee/fusee-secondary/src/key_derivation.h
@@ -17,8 +17,7 @@
 typedef enum {
     BisPartition_Calibration = 0,
     BisPartition_Safe = 1,
-    BisPartition_User = 2,
-    BisPartition_System = 3
+    BisPartition_UserSystem = 2
 } BisPartition_t;
 
 typedef struct {

--- a/fusee/fusee-secondary/src/key_derivation.h
+++ b/fusee/fusee-secondary/src/key_derivation.h
@@ -16,8 +16,9 @@
 
 typedef enum {
     BisPartition_Calibration = 0,
-    BisPartition_User = 1,
-    BisPartition_System = 2
+	BisPartition_Safe = 1,
+    BisPartition_User = 2,
+    BisPartition_System = 3
 } BisPartition_t;
 
 typedef struct {


### PR DESCRIPTION
Fix this off-by-one problem