### PR TITLE
fusee: fix sd carry over from stage 1 to 2

### DIFF
--- a/fusee/fusee-primary/src/sd_utils.c
+++ b/fusee/fusee-primary/src/sd_utils.c
@@ -12,7 +12,7 @@ static int mounted_sd = 0;
 
 void save_sd_state(void **mmc, void **ff) {
     *mmc = &sd_mmc;
-    *ff = &ff;
+    *ff = &sd_fs;
 }
 void resume_sd_state(void *mmc, void *ff) {
     sd_mmc = *(struct mmc *)mmc;

--- a/fusee/fusee-secondary/src/main.c
+++ b/fusee/fusee-secondary/src/main.c
@@ -30,10 +30,10 @@ int main(int argc, void **argv) {
         generic_panic();
     }
 
-    resume_sd_state((struct mmc *)args.sd_mmc, (FATFS *)args.sd_fs);
-
     /* Copy the BCT0 from unsafe primary memory into our memory. */
     strncpy(g_bct0, args.bct0, sizeof(g_bct0));
+
+    resume_sd_state((struct mmc *)args.sd_mmc, (FATFS *)args.sd_fs);
 
     /* TODO: What other hardware init should we do here? */
 

--- a/fusee/fusee-secondary/src/sd_utils.c
+++ b/fusee/fusee-secondary/src/sd_utils.c
@@ -12,7 +12,7 @@ static int mounted_sd = 0;
 
 void save_sd_state(void **mmc, void **ff) {
     *mmc = &sd_mmc;
-    *ff = &ff;
+    *ff = &sd_fs;
 }
 void resume_sd_state(void *mmc, void *ff) {
     sd_mmc = *(struct mmc *)mmc;


### PR DESCRIPTION
I can't explain why, but it seems doing that strncpy after the SD gets resumed breaks something cause the state of the SD being already initialized and mounted gets lost by this.
The other two changes seemed obvious.

Mind you I still can't read from SD in stage2, FatFS keeps returning FR_NOT_ENABLED.