### PR TITLE
ldr: Fix printf format string for size_t

### DIFF
--- a/stratosphere/loader/source/ldr_debug_monitor.cpp
+++ b/stratosphere/loader/source/ldr_debug_monitor.cpp
@@ -26,7 +26,7 @@ Result DebugMonitorService::dispatch(IpcParsedCommand &r, IpcCommand &out_c, u64
 }
 
 std::tuple<Result> DebugMonitorService::add_title_to_launch_queue(u64 tid, InPointer<char> args) {
-    fprintf(stderr, "Add to launch queue: %p, %X\n", args.pointer, args.num_elements);
+    fprintf(stderr, "Add to launch queue: %p, %zX\n", args.pointer, args.num_elements);
     return {LaunchQueue::add(tid, args.pointer, args.num_elements)};
 }
 

--- a/stratosphere/loader/source/ldr_shell.cpp
+++ b/stratosphere/loader/source/ldr_shell.cpp
@@ -20,7 +20,7 @@ Result ShellService::dispatch(IpcParsedCommand &r, IpcCommand &out_c, u64 cmd_id
 }
 
 std::tuple<Result> ShellService::add_title_to_launch_queue(u64 tid, InPointer<char> args) {
-    fprintf(stderr, "Add to launch queue: %p, %X\n", args.pointer, args.num_elements);
+    fprintf(stderr, "Add to launch queue: %p, %zX\n", args.pointer, args.num_elements);
     return {LaunchQueue::add(tid, args.pointer, args.num_elements)};
 }
 


### PR DESCRIPTION
%z should be used for size_t, otherwise the wrong value may be printed.

Fixes two -Wformat warnings.