### PR TITLE
Fix stage2_args_t mismatch

### DIFF
--- a/fusee/fusee-primary/src/init.c
+++ b/fusee/fusee-primary/src/init.c
@@ -90,7 +90,7 @@ static void __program_parse_argc_argv(int argc, char *argdata) {
     strcpy((char *)__program_argv[0], argdata);
     pos += len + 1;
 
-    __program_argv[1] = malloc(len + 1);
+    __program_argv[1] = malloc(sizeof(stage2_args_t));
     if (__program_argv[1] == NULL) {
         generic_panic();
     }

--- a/fusee/fusee-primary/src/stage2.h
+++ b/fusee/fusee-primary/src/stage2.h
@@ -21,9 +21,6 @@ typedef struct {
 
 typedef struct {
     uint32_t version;
-    uint32_t *lfb;
-    uint32_t console_row;
-    uint32_t console_col;
     char bct0[BCTO_MAX_SIZE];
 } stage2_args_t;
 

--- a/fusee/fusee-secondary/src/init.c
+++ b/fusee/fusee-secondary/src/init.c
@@ -90,7 +90,7 @@ static void __program_parse_argc_argv(int argc, char *argdata) {
     strcpy((char *)__program_argv[0], argdata);
     pos += len + 1;
 
-    __program_argv[1] = malloc(len + 1);
+    __program_argv[1] = malloc(sizeof(stage2_args_t));
     if (__program_argv[1] == NULL) {
         generic_panic();
     }


### PR DESCRIPTION
fixes a couple bugs introduced by e8306361f06132fc1ecc14070bd77c2b4e564dcd

~stage2 is only receiving the first 18 bytes of the bct, don't know what's going on there yet~