### PR TITLE
Allow for untracked config.h

### DIFF
--- a/fusee/fusee-primary/Makefile
+++ b/fusee/fusee-primary/Makefile
@@ -30,6 +30,10 @@ CFLAGS = \
 	-fstrict-volatile-bitfields \
 	-DFUSEE_STAGE1_SRC
 
+ifneq (,$(wildcard src/config.h))
+	CFLAGS += -DHAS_CONFIG_H
+endif
+
 LDFLAGS = -specs=linker.specs -g $(ARCH)
 
 objects =	$(patsubst $(dir_source)/%.s, $(dir_build)/%.o, \

--- a/fusee/fusee-primary/src/main.c
+++ b/fusee/fusee-primary/src/main.c
@@ -10,6 +10,10 @@
 #include "lib/printk.h"
 #include "display/video_fb.h"
 
+#ifdef HAS_CONFIG_H
+#include "config.h"
+#endif
+
 extern void (*__program_exit_callback)(int rc);
 
 static void *g_framebuffer;


### PR DESCRIPTION
`#include "src/config.h"` if it exists in fusée primary