### PR TITLE
Fix ini.c for GCC 8

### DIFF
--- a/fusee/fusee-primary/src/lib/ini.c
+++ b/fusee/fusee-primary/src/lib/ini.c
@@ -67,14 +67,6 @@ static char* find_chars_or_comment(const char* s, const char* chars)
     return (char*)s;
 }
 
-/* Version of strncpy that ensures dest (size bytes) is null-terminated. */
-static char* strncpy0(char* dest, const char* src, size_t size)
-{
-    strncpy(dest, src, size);
-    dest[size - 1] = '\0';
-    return dest;
-}
-
 /* See documentation in header file. */
 int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
                      void* user)
@@ -164,7 +156,7 @@ int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
             end = find_chars_or_comment(start + 1, "]");
             if (*end == ']') {
                 *end = '\0';
-                strncpy0(section, start + 1, sizeof(section));
+                strlcpy(section, start + 1, sizeof(section));
                 *prev_name = '\0';
             }
             else if (!error) {
@@ -188,7 +180,7 @@ int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
                 rstrip(value);
 
                 /* Valid name[=:]value pair found, call handler */
-                strncpy0(prev_name, name, sizeof(prev_name));
+                strlcpy(prev_name, name, sizeof(prev_name));
                 if (!HANDLER(user, section, name, value) && !error)
                     error = lineno;
             }

--- a/fusee/fusee-secondary/src/lib/ini.c
+++ b/fusee/fusee-secondary/src/lib/ini.c
@@ -67,14 +67,6 @@ static char* find_chars_or_comment(const char* s, const char* chars)
     return (char*)s;
 }
 
-/* Version of strncpy that ensures dest (size bytes) is null-terminated. */
-static char* strncpy0(char* dest, const char* src, size_t size)
-{
-    strncpy(dest, src, size);
-    dest[size - 1] = '\0';
-    return dest;
-}
-
 /* See documentation in header file. */
 int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
                      void* user)
@@ -164,7 +156,7 @@ int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
             end = find_chars_or_comment(start + 1, "]");
             if (*end == ']') {
                 *end = '\0';
-                strncpy0(section, start + 1, sizeof(section));
+                strlcpy(section, start + 1, sizeof(section));
                 *prev_name = '\0';
             }
             else if (!error) {
@@ -188,7 +180,7 @@ int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
                 rstrip(value);
 
                 /* Valid name[=:]value pair found, call handler */
-                strncpy0(prev_name, name, sizeof(prev_name));
+                strlcpy(prev_name, name, sizeof(prev_name));
                 if (!HANDLER(user, section, name, value) && !error)
                     error = lineno;
             }

--- a/thermosphere/src/lib/ini.c
+++ b/thermosphere/src/lib/ini.c
@@ -67,14 +67,6 @@ static char* find_chars_or_comment(const char* s, const char* chars)
     return (char*)s;
 }
 
-/* Version of strncpy that ensures dest (size bytes) is null-terminated. */
-static char* strncpy0(char* dest, const char* src, size_t size)
-{
-    strncpy(dest, src, size);
-    dest[size - 1] = '\0';
-    return dest;
-}
-
 /* See documentation in header file. */
 int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
                      void* user)
@@ -164,7 +156,7 @@ int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
             end = find_chars_or_comment(start + 1, "]");
             if (*end == ']') {
                 *end = '\0';
-                strncpy0(section, start + 1, sizeof(section));
+                strlcpy(section, start + 1, sizeof(section));
                 *prev_name = '\0';
             }
             else if (!error) {
@@ -188,7 +180,7 @@ int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
                 rstrip(value);
 
                 /* Valid name[=:]value pair found, call handler */
-                strncpy0(prev_name, name, sizeof(prev_name));
+                strlcpy(prev_name, name, sizeof(prev_name));
                 if (!HANDLER(user, section, name, value) && !error)
                     error = lineno;
             }


### PR DESCRIPTION
Using `aarch64-none-elf-gcc (devkitA64 release 9) 8.1.0`, the following errors occur:

```
In function 'strncpy0',
    inlined from 'ini_parse_stream' at src/lib/ini.c:191:17:
src/lib/ini.c:73:5: error: 'strncpy' specified bound 50 equals destination size [-Werror=stringop-truncation]
     strncpy(dest, src, size);
     ^~~~~~~~~~~~~~~~~~~~~~~~
In function 'strncpy0',
    inlined from 'ini_parse_stream' at src/lib/ini.c:167:17:
src/lib/ini.c:73:5: error: 'strncpy' specified bound 50 equals destination size [-Werror=stringop-truncation]
     strncpy(dest, src, size);
     ^~~~~~~~~~~~~~~~~~~~~~~~
```

This replaces calls to `strncpy0` with `strlcpy`, which provides the same behavior.