### PR TITLE
Set SDMMC controller to SDR104 as a workaround

### DIFF
--- a/fusee/fusee-primary/src/sdmmc.c
+++ b/fusee/fusee-primary/src/sdmmc.c
@@ -1360,7 +1360,8 @@ static int sdmmc_apply_clock_speed(struct mmc *mmc, enum sdmmc_bus_speed speed, 
         case SDMMC_SPEED_SDR50:
             mmc->regs->host_control |= MMC_HOST_ENABLE_HIGH_SPEED;
             mmc->configure_clock(mmc, MMC_CLOCK_SOURCE_SDR50, MMC_CLOCK_DIVIDER_SDR50, MMC_CLOCK_CONTROL_FREQUENCY_PASSTHROUGH);
-            sdmmc_set_uhs_mode(mmc, SDMMC_SPEED_SDR50);
+            // Tegra X1 Series Processors Silicon Errata MMC-2 mentions setting SDR104 mode as workaround.
+            sdmmc_set_uhs_mode(mmc, SDMMC_SPEED_SDR104);
 
             execute_tuning = true;
             tuning_attempts = MMC_VENDOR_TUNING_TRIES_SDR50;

--- a/fusee/fusee-secondary/src/sdmmc.c
+++ b/fusee/fusee-secondary/src/sdmmc.c
@@ -1360,7 +1360,8 @@ static int sdmmc_apply_clock_speed(struct mmc *mmc, enum sdmmc_bus_speed speed, 
         case SDMMC_SPEED_SDR50:
             mmc->regs->host_control |= MMC_HOST_ENABLE_HIGH_SPEED;
             mmc->configure_clock(mmc, MMC_CLOCK_SOURCE_SDR50, MMC_CLOCK_DIVIDER_SDR50, MMC_CLOCK_CONTROL_FREQUENCY_PASSTHROUGH);
-            sdmmc_set_uhs_mode(mmc, SDMMC_SPEED_SDR50);
+            // Tegra X1 Series Processors Silicon Errata MMC-2 mentions setting SDR104 mode as workaround.
+            sdmmc_set_uhs_mode(mmc, SDMMC_SPEED_SDR104);
 
             execute_tuning = true;
             tuning_attempts = MMC_VENDOR_TUNING_TRIES_SDR50;


### PR DESCRIPTION
According to Tegra X1 Series Processors Silicon Errata there is possible
misalignment of received data which results in a CRC error. The issue is
present only in SDR50 mode.

I didn't check this code. I wanted to start discussion about this on the discord, however I don't have permissions to post to the development channel. Hence I decided a pull request is going to be best way to get it mentioned/discussed.

I didn't yet traverse through the full datasheet nor the driver code, so the change might break something.