### PR TITLE
Use "final" and "override" where appropriate

### DIFF
--- a/stratosphere/libstratosphere/include/stratosphere/iserviceobject.hpp
+++ b/stratosphere/libstratosphere/include/stratosphere/iserviceobject.hpp
@@ -4,7 +4,7 @@
 #include "ipc_templating.hpp"
 
 class IServiceObject {
-    public:
+    protected:
         virtual ~IServiceObject() { }
         virtual Result dispatch(IpcParsedCommand &r, IpcCommand &out_c, u64 cmd_id, u8 *pointer_buffer, size_t pointer_buffer_size) = 0;
         virtual Result handle_deferred() = 0;

--- a/stratosphere/libstratosphere/include/stratosphere/servicesession.hpp
+++ b/stratosphere/libstratosphere/include/stratosphere/servicesession.hpp
@@ -23,7 +23,7 @@ template <typename T>
 class IServer;
 
 template <typename T>
-class ServiceSession : public IWaitable {
+class ServiceSession final : public IWaitable {
     static_assert(std::is_base_of<IServiceObject, T>::value, "Service Objects must derive from IServiceObject");
     
     T *service_object;
@@ -39,7 +39,7 @@ class ServiceSession : public IWaitable {
             this->service_object = new T();
         }
         
-        virtual ~ServiceSession() {
+        ~ServiceSession() override {
             delete this->service_object;
             if (server_handle) {
                 svcCloseHandle(server_handle);
@@ -54,23 +54,23 @@ class ServiceSession : public IWaitable {
         Handle get_client_handle() { return this->client_handle; }
         
         /* IWaitable */
-        virtual unsigned int get_num_waitables() {
+        unsigned int get_num_waitables() override {
             return 1;
         }
         
-        virtual void get_waitables(IWaitable **dst) {
+        void get_waitables(IWaitable **dst) override {
             dst[0] = this;
         }
         
-        virtual void delete_child(IWaitable *child) {
+        void delete_child(IWaitable *child) override {
             /* TODO: Panic, because we can never have any children. */
         }
         
-        virtual Handle get_handle() {
+        Handle get_handle() override {
             return this->server_handle;
         }
         
-        virtual void handle_deferred() {
+        void handle_deferred() override {
             Result rc = this->service_object->handle_deferred();
             int handle_index;
             
@@ -84,7 +84,7 @@ class ServiceSession : public IWaitable {
             }
         }
         
-        virtual Result handle_signaled(u64 timeout) {
+        Result handle_signaled(u64 timeout) override {
             Result rc;
             int handle_index;
             

--- a/stratosphere/libstratosphere/include/stratosphere/systemevent.hpp
+++ b/stratosphere/libstratosphere/include/stratosphere/systemevent.hpp
@@ -7,7 +7,7 @@
 #define SYSTEMEVENT_INDEX_WAITHANDLE 0
 #define SYSTEMEVENT_INDEX_SGNLHANDLE 1
 
-class SystemEvent : public IEvent {
+class SystemEvent final : public IEvent {
     public:
         SystemEvent(EventCallback callback) : IEvent(0, callback) {
             Handle wait_h;
@@ -20,7 +20,7 @@ class SystemEvent : public IEvent {
             this->handles.push_back(sig_h);
         }
         
-        virtual Result signal_event() {
+        Result signal_event() override {
             return svcSignalEvent(this->handles[SYSTEMEVENT_INDEX_SGNLHANDLE]);
         }  
 };

--- a/stratosphere/loader/source/ldr_debug_monitor.hpp
+++ b/stratosphere/loader/source/ldr_debug_monitor.hpp
@@ -10,10 +10,10 @@ enum DebugMonitorServiceCmd {
     Dmnt_Cmd_GetNsoInfo = 2
 };
 
-class DebugMonitorService : IServiceObject {
+class DebugMonitorService final : IServiceObject {
     public:
-        virtual Result dispatch(IpcParsedCommand &r, IpcCommand &out_c, u64 cmd_id, u8 *pointer_buffer, size_t pointer_buffer_size);
-        virtual Result handle_deferred() {
+        Result dispatch(IpcParsedCommand &r, IpcCommand &out_c, u64 cmd_id, u8 *pointer_buffer, size_t pointer_buffer_size) override;
+        Result handle_deferred() override {
             /* This service will never defer. */
             return 0;
         }

--- a/stratosphere/loader/source/ldr_process_manager.hpp
+++ b/stratosphere/loader/source/ldr_process_manager.hpp
@@ -12,7 +12,7 @@ enum ProcessManagerServiceCmd {
     Pm_Cmd_UnregisterTitle = 3
 };
 
-class ProcessManagerService : IServiceObject {
+class ProcessManagerService final : IServiceObject {
     struct ProgramInfo {
         u8 main_thread_priority;
         u8 default_cpu_id;
@@ -29,8 +29,8 @@ class ProcessManagerService : IServiceObject {
     static_assert(sizeof(ProcessManagerService::ProgramInfo) == 0x400, "Incorrect ProgramInfo definition.");
     
     public:
-        virtual Result dispatch(IpcParsedCommand &r, IpcCommand &out_c, u64 cmd_id, u8 *pointer_buffer, size_t pointer_buffer_size);
-        virtual Result handle_deferred() {
+        Result dispatch(IpcParsedCommand &r, IpcCommand &out_c, u64 cmd_id, u8 *pointer_buffer, size_t pointer_buffer_size) override;
+        Result handle_deferred() override {
             /* This service will never defer. */
             return 0;
         }

--- a/stratosphere/loader/source/ldr_ro_service.hpp
+++ b/stratosphere/loader/source/ldr_ro_service.hpp
@@ -12,7 +12,7 @@ enum RoServiceCmd {
     Ro_Cmd_Initialize = 4,
 };
 
-class RelocatableObjectsService : IServiceObject {
+class RelocatableObjectsService final : IServiceObject {
     Handle process_handle;
     u64 process_id;
     bool has_initialized;
@@ -24,8 +24,8 @@ class RelocatableObjectsService : IServiceObject {
                 svcCloseHandle(this->process_handle);
             }
         }
-        virtual Result dispatch(IpcParsedCommand &r, IpcCommand &out_c, u64 cmd_id, u8 *pointer_buffer, size_t pointer_buffer_size);
-        virtual Result handle_deferred() {
+        Result dispatch(IpcParsedCommand &r, IpcCommand &out_c, u64 cmd_id, u8 *pointer_buffer, size_t pointer_buffer_size) override;
+        Result handle_deferred() override {
             /* This service will never defer. */
             return 0;
         }

--- a/stratosphere/loader/source/ldr_shell.hpp
+++ b/stratosphere/loader/source/ldr_shell.hpp
@@ -7,10 +7,10 @@ enum ShellServiceCmd {
     Shell_Cmd_ClearLaunchQueue = 1
 };
 
-class ShellService : IServiceObject {
+class ShellService final : IServiceObject {
     public:
-        virtual Result dispatch(IpcParsedCommand &r, IpcCommand &out_c, u64 cmd_id, u8 *pointer_buffer, size_t pointer_buffer_size);
-        virtual Result handle_deferred() {
+        Result dispatch(IpcParsedCommand &r, IpcCommand &out_c, u64 cmd_id, u8 *pointer_buffer, size_t pointer_buffer_size) override;
+        Result handle_deferred() override {
             /* This service will never defer. */
             return 0;
         }

--- a/stratosphere/pm/source/pm_boot_mode.hpp
+++ b/stratosphere/pm/source/pm_boot_mode.hpp
@@ -7,10 +7,10 @@ enum BootModeCmd {
     BootMode_Cmd_SetMaintenanceBoot = 1
 };
 
-class BootModeService : IServiceObject {
+class BootModeService final : IServiceObject, public IpcCommandWrapper<BootModeService> {
     public:
-        virtual Result dispatch(IpcParsedCommand &r, IpcCommand &out_c, u64 cmd_id, u8 *pointer_buffer, size_t pointer_buffer_size);
-        virtual Result handle_deferred();
+        Result dispatch(IpcParsedCommand &r, IpcCommand &out_c, u64 cmd_id, u8 *pointer_buffer, size_t pointer_buffer_size) override;
+        Result handle_deferred() override;
         
     private:
         /* Actual commands. */

--- a/stratosphere/pm/source/pm_debug_monitor.hpp
+++ b/stratosphere/pm/source/pm_debug_monitor.hpp
@@ -23,10 +23,10 @@ enum DmntCmd_5X {
     Dmnt_Cmd_5X_EnableDebugForApplication = 5,
 };
 
-class DebugMonitorService : IServiceObject {
+class DebugMonitorService final : IServiceObject {
     public:
-        virtual Result dispatch(IpcParsedCommand &r, IpcCommand &out_c, u64 cmd_id, u8 *pointer_buffer, size_t pointer_buffer_size);
-        virtual Result handle_deferred();
+        Result dispatch(IpcParsedCommand &r, IpcCommand &out_c, u64 cmd_id, u8 *pointer_buffer, size_t pointer_buffer_size) override;
+        Result handle_deferred() override;
         
     private:
         /* Actual commands. */

--- a/stratosphere/pm/source/pm_info.hpp
+++ b/stratosphere/pm/source/pm_info.hpp
@@ -6,10 +6,10 @@ enum InformationCmd {
     Information_Cmd_GetTitleId = 0,
 };
 
-class InformationService : IServiceObject {
+class InformationService final : IServiceObject {
     public:
-        virtual Result dispatch(IpcParsedCommand &r, IpcCommand &out_c, u64 cmd_id, u8 *pointer_buffer, size_t pointer_buffer_size);
-        virtual Result handle_deferred();
+        Result dispatch(IpcParsedCommand &r, IpcCommand &out_c, u64 cmd_id, u8 *pointer_buffer, size_t pointer_buffer_size) override;
+        Result handle_deferred() override;
         
     private:
         /* Actual commands. */

--- a/stratosphere/pm/source/pm_process_wait.hpp
+++ b/stratosphere/pm/source/pm_process_wait.hpp
@@ -2,7 +2,7 @@
 #include <switch.h>
 #include <stratosphere.hpp>
 
-class ProcessWaiter : public IWaitable {
+class ProcessWaiter final : public IWaitable {
     public:
         Registration::Process process;
         
@@ -19,33 +19,33 @@ class ProcessWaiter : public IWaitable {
         }
         
         /* IWaitable */
-        virtual unsigned int get_num_waitables() {
+        unsigned int get_num_waitables() override {
             return 1;
         }
         
-        virtual void get_waitables(IWaitable **dst) {
+        void get_waitables(IWaitable **dst) override {
             dst[0] = this;
         }
         
-        virtual void delete_child(IWaitable *child) {
+        void delete_child(IWaitable *child) override {
             /* TODO: Panic, because we can never have any children. */
         }
         
-        virtual Handle get_handle() {
+        Handle get_handle() override {
             return this->process.handle;
         }
         
-        virtual void handle_deferred() {
+        void handle_deferred() override {
             /* TODO: Panic, because we can never be deferred. */
         }
         
-        virtual Result handle_signaled(u64 timeout) {
+        Result handle_signaled(u64 timeout) override {
             Registration::HandleSignaledProcess(this->get_process());
             return 0;
         }
 };
 
-class ProcessList : public IWaitable {
+class ProcessList final : public IWaitable {
     private:      
         HosRecursiveMutex mutex;
     public:
@@ -64,11 +64,11 @@ class ProcessList : public IWaitable {
         }
         
         /* IWaitable */
-        virtual unsigned int get_num_waitables() {
+        unsigned int get_num_waitables() override {
             return process_waiters.size();
         }
         
-        virtual void get_waitables(IWaitable **dst) {
+        void get_waitables(IWaitable **dst) override {
             Lock();
             for (unsigned int i = 0; i < process_waiters.size(); i++) {
                 dst[i] = process_waiters[i];
@@ -76,20 +76,20 @@ class ProcessList : public IWaitable {
             Unlock();
         }
         
-        virtual void delete_child(IWaitable *child) {
+        void delete_child(IWaitable *child) override {
             /* TODO: Panic, because we should never be asked to delete a child. */
         }
         
-        virtual Handle get_handle() {
+        Handle get_handle() override {
             /* TODO: Panic, because we don't have a handle. */
             return 0;
         }
         
-        virtual void handle_deferred() {
+        void handle_deferred() override {
             /* TODO: Panic, because we can never be deferred. */
         }
         
-        virtual Result handle_signaled(u64 timeout) {
+        Result handle_signaled(u64 timeout) override {
             /* TODO: Panic, because we can never be signaled. */         
             return 0;
         }

--- a/stratosphere/pm/source/pm_shell.hpp
+++ b/stratosphere/pm/source/pm_shell.hpp
@@ -30,10 +30,10 @@ enum ShellCmd_5X {
     Shell_Cmd_5X_BoostSystemMemoryResourceLimit = 7
 };
 
-class ShellService : IServiceObject {
+class ShellService final : IServiceObject {
     public:
-        virtual Result dispatch(IpcParsedCommand &r, IpcCommand &out_c, u64 cmd_id, u8 *pointer_buffer, size_t pointer_buffer_size);
-        virtual Result handle_deferred();
+        Result dispatch(IpcParsedCommand &r, IpcCommand &out_c, u64 cmd_id, u8 *pointer_buffer, size_t pointer_buffer_size) override;
+        Result handle_deferred() override;
         
     private:
         /* Actual commands. */

--- a/stratosphere/sm/source/sm_manager_service.hpp
+++ b/stratosphere/sm/source/sm_manager_service.hpp
@@ -7,10 +7,10 @@ enum ManagerServiceCmd {
     Manager_Cmd_UnregisterProcess = 1
 };
 
-class ManagerService : IServiceObject {
+class ManagerService final : IServiceObject {
     public:
-        virtual Result dispatch(IpcParsedCommand &r, IpcCommand &out_c, u64 cmd_id, u8 *pointer_buffer, size_t pointer_buffer_size);
-        virtual Result handle_deferred();
+        Result dispatch(IpcParsedCommand &r, IpcCommand &out_c, u64 cmd_id, u8 *pointer_buffer, size_t pointer_buffer_size) override;
+        Result handle_deferred() override;
         
     private:
         /* Actual commands. */

--- a/stratosphere/sm/source/sm_user_service.hpp
+++ b/stratosphere/sm/source/sm_user_service.hpp
@@ -9,15 +9,15 @@ enum UserServiceCmd {
     User_Cmd_UnregisterService = 3
 };
 
-class UserService : IServiceObject {
+class UserService final : IServiceObject {
     u64 pid;
     bool has_initialized;
     u64 deferred_service;
     
     public:
         UserService() : pid(U64_MAX), has_initialized(false), deferred_service(0) { }
-        virtual Result dispatch(IpcParsedCommand &r, IpcCommand &out_c, u64 cmd_id, u8 *pointer_buffer, size_t pointer_buffer_size);
-        virtual Result handle_deferred();
+        Result dispatch(IpcParsedCommand &r, IpcCommand &out_c, u64 cmd_id, u8 *pointer_buffer, size_t pointer_buffer_size) override;
+        Result handle_deferred() override;
         
     private:
         /* Actual commands. */


### PR DESCRIPTION
These keywords were introduced in C++11 for the sake of catching bugs and improving code expressiveness:

* "override" ensures the given member function actually overrides one of the base class's member functions (which can be easy to mess up by picking the wrong types or function names)
* "final" classes may not be inherited from; this implies that none of its child methods will ever be overridden. This is useful when browsing through the source (easy to identify concrete classes that will be instantiated), and it also helps the compiler optimizer at devirtualization.
