### PR TITLE
Fix CCPLEX bringup and halt the BPMP once it's done booting.

### DIFF
--- a/fusee/fusee-secondary/src/hwinit/cluster.c
+++ b/fusee/fusee-secondary/src/hwinit/cluster.c
@@ -63,6 +63,8 @@ void cluster_enable_cpu0(u64 entry, u32 ns_disable)
 	{
 		CLOCK(0x518) &= 0xFFFFFFF7;
 		sleep(2);
+		CLOCK(0xE0) = 0x80404E02;
+		CLOCK(0xE0) = 0x404E02;
 		CLOCK(0xE4) = CLOCK(0xE4) & 0xFFFBFFFF | 0x40000;
 		CLOCK(0xE0) = 0x40404E02;
 	}
@@ -77,7 +79,7 @@ void cluster_enable_cpu0(u64 entry, u32 ns_disable)
 
 	clock_enable_coresight();
 
-	CLOCK(0x388) = CLOCK(0x388) & 0xFFFFE000;
+	CLOCK(0x388) = CLOCK(0x388) & 0xFFFFF000;
 
 	//Enable CPU rail.
 	_cluster_pmc_enable_partition(1, 0);
@@ -110,5 +112,6 @@ void cluster_enable_cpu0(u64 entry, u32 ns_disable)
 
 	//Until here the CPU was in reset, this kicks execution.
 	CLOCK(CLK_RST_CONTROLLER_RST_DEVICES_V) &= 0xFFFFFFF7;
+	CLOCK(CLK_RST_CONTROLLER_RST_CPUG_CMPLX_CLR) = 0x20000000;
 	CLOCK(CLK_RST_CONTROLLER_RST_CPUG_CMPLX_CLR) = 0x411F000F;
 }

--- a/fusee/fusee-secondary/src/nxboot.c
+++ b/fusee/fusee-secondary/src/nxboot.c
@@ -14,6 +14,7 @@
 #include "exocfg.h"
 #include "display/video_fb.h"
 #include "lib/ini.h"
+#include "hwinit/t210.h"
 
 #define u8 uint8_t
 #define u32 uint32_t
@@ -247,5 +248,8 @@ void nxboot_main(void) {
     /* Display splash screen. */
     display_splash_screen_bmp(loader_ctx->custom_splash_path);
 
-    /* TODO: Halt ourselves. */
+    //Halt ourselves in waitevent state.
+    while (1) {
+        FLOW_CTLR(0x4) = 0x50000000;
+    }
 }


### PR DESCRIPTION
I have only tested this on a branch without the latest sdmmc driver, but I guess that won't have any side-effects. The changes were made after comparing the relevant sections in hekate.