### PR TITLE
package2 verification and ini1 merging fixes

### DIFF
--- a/fusee/fusee-secondary/Makefile
+++ b/fusee/fusee-secondary/Makefile
@@ -108,7 +108,7 @@ export INCLUDE	:=	$(foreach dir,$(INCLUDES),-I$(CURDIR)/$(dir)) \
 export LIBPATHS	:=	$(foreach dir,$(LIBDIRS),-L$(dir)/lib)
 
 .PHONY: $(BUILD) clean all
-.PHONY: check_exosphere check_thermosphere check_exosphere
+.PHONY: check_exosphere check_thermosphere check_stratosphere
 
 #---------------------------------------------------------------------------------
 all: $(BUILD)

--- a/fusee/fusee-secondary/src/stratosphere.c
+++ b/fusee/fusee-secondary/src/stratosphere.c
@@ -120,6 +120,8 @@ ini1_header_t *stratosphere_merge_inis(ini1_header_t **inis, size_t num_inis) {
                 fatal_error("INI1s[%zu][%zu] appears not to be a KIP1!\n", i, p);
             }
 
+            offset += kip1_get_size_from_header(current_kip);
+            
             bool already_loaded = false;
             for (uint32_t j = 0; j < merged->num_processes; j++) {
                 if (process_list[j] == current_kip->title_id) {


### PR DESCRIPTION
Two things in this PR:

1) The offset for reading kip1s was never incremented so the merging function would only ever try to merge the first KIP1 of each INI1. Sample hactool output for a package2 built with this fix: https://pastebin.com/WDVAwdMe

2) Based on the suggestion by Thog, the second commit fixes package2 verification by passing along the data to be hashed. For this one I'm not sure if this is good style so feel free to let me know and I can change or remove it from the PR :)

Oh, and a small Makefile fix.