### PR TITLE
Turn on the display onces the framebuffer is ready

### DIFF
--- a/fusee/fusee-secondary/src/console.c
+++ b/fusee/fusee-secondary/src/console.c
@@ -158,7 +158,7 @@ int console_init(bool display_initialized) {
         console_end();
         return -1;
     }
-
+    console_display(g_framebuffer);
     return 0;
 }
 


### PR DESCRIPTION
After creating the framebuffer and filling it with 0's we can turn the display on right away.

I put this in console_init() since it is able to directly reference g_framebuffer. An alternative location for this would be in setup_env() in main.c but I believe you'd have to make a call to get the g_framebuffer address.