### PR TITLE
PM: Remove magic numbers for flags and events to improve readability and understandability

### DIFF
--- a/stratosphere/pm/source/pm_registration.cpp
+++ b/stratosphere/pm/source/pm_registration.cpp
@@ -105,16 +105,16 @@ void Registration::HandleProcessLaunch() {
         
     /* Setup process flags. */
     if (program_info.application_type & 1) {
-        new_process.flags |= 0x40;
+        new_process.flags |= PROCESSFLAGS_APPLICATION;
     }
     if (kernelAbove200() && LAUNCHFLAGS_NOTIYDEBUGSPECIAL(launch_flags) && (program_info.application_type & 4)) { 
-        new_process.flags |= 0x80;
+        new_process.flags |= PROCESSFLAGS_NOTIFYDEBUGSPECIAL;
     }
     if (LAUNCHFLAGS_NOTIFYWHENEXITED(launch_flags)) {
-        new_process.flags |= 1;
+        new_process.flags |= PROCESSFLAGS_NOTIFYWHENEXITED;
     }
     if (LAUNCHFLAGS_NOTIFYDEBUGEVENTS(launch_flags) && (!kernelAbove200() || (program_info.application_type & 4))) {
-        new_process.flags |= 0x8;
+        new_process.flags |= PROCESSFLAGS_NOTIFYDEBUGEVENTS;
     }
     
     /* Add process to the list. */
@@ -125,7 +125,7 @@ void Registration::HandleProcessLaunch() {
         g_debug_title_event->signal_event();
         g_debug_on_launch_tid = 0;
         rc = 0;
-    } else if ((new_process.flags & 0x40) && g_debug_next_application.load()) {
+    } else if ((new_process.flags & PROCESSFLAGS_APPLICATION) && g_debug_next_application.load()) {
         g_debug_application_event->signal_event();
         g_debug_next_application = false;
         rc = 0;
@@ -226,7 +226,7 @@ Result Registration::HandleSignaledProcess(std::shared_ptr<Registration::Process
     process->state = (ProcessState)tmp;
     
     if (old_state == ProcessState_Crashed && process->state != ProcessState_Crashed) {
-        process->flags &= ~0x4;
+        process->flags &= ~PROCESSFLAGS_CRASH_DEBUG;
     }
     switch (process->state) {
         case ProcessState_Created:
@@ -234,37 +234,37 @@ Result Registration::HandleSignaledProcess(std::shared_ptr<Registration::Process
         case ProcessState_Exiting:
             break;
         case ProcessState_DebugDetached:
-            if (process->flags & 8) {
-                process->flags &= ~0x30;
-                process->flags |= 0x10;
+            if (process->flags & PROCESSFLAGS_NOTIFYDEBUGEVENTS) {
+                process->flags &= ~(PROCESSFLAGS_DEBUGEVENTPENDING | PROCESSFLAGS_DEBUGSUSPENDED);
+                process->flags |= PROCESSFLAGS_DEBUGEVENTPENDING;
                 g_process_event->signal_event();
             }
-            if (kernelAbove200() && process->flags & 0x80) {
-                process->flags &= ~0x180;
-                process->flags |= 0x100;
+            if (kernelAbove200() && process->flags & PROCESSFLAGS_NOTIFYDEBUGSPECIAL) {
+                process->flags &= ~(PROCESSFLAGS_NOTIFYDEBUGSPECIAL | PROCESSFLAGS_DEBUGDETACHED);
+                process->flags |= PROCESSFLAGS_DEBUGDETACHED;
             }
             break;
         case ProcessState_Crashed:
-            process->flags |= 6;
+            process->flags |= (PROCESSFLAGS_CRASHED | PROCESSFLAGS_CRASH_DEBUG);
             g_process_event->signal_event();
             break;
         case ProcessState_Running:
-            if (process->flags & 8) {
-                process->flags &= ~0x30;
-                process->flags |= 0x10;
+            if (process->flags & PROCESSFLAGS_NOTIFYDEBUGEVENTS) {
+                process->flags &= ~(PROCESSFLAGS_DEBUGEVENTPENDING | PROCESSFLAGS_DEBUGSUSPENDED);
+                process->flags |= PROCESSFLAGS_DEBUGEVENTPENDING;
                 g_process_event->signal_event();
             }
             break;
         case ProcessState_Exited:
-            if (process->flags & 1 && !kernelAbove500()) {
+            if (process->flags & PROCESSFLAGS_NOTIFYWHENEXITED && !kernelAbove500()) {
                 g_process_event->signal_event();
             } else {
                 FinalizeExitedProcess(process);
             }
             return 0xF601;
         case ProcessState_DebugSuspended:
-            if (process->flags & 8) {
-                process->flags |= 0x30;
+            if (process->flags & PROCESSFLAGS_NOTIFYDEBUGEVENTS) {
+                process->flags |= (PROCESSFLAGS_DEBUGEVENTPENDING | PROCESSFLAGS_DEBUGSUSPENDED);
                 g_process_event->signal_event();
             }
             break;
@@ -274,7 +274,7 @@ Result Registration::HandleSignaledProcess(std::shared_ptr<Registration::Process
 
 void Registration::FinalizeExitedProcess(std::shared_ptr<Registration::Process> process) {
     auto auto_lock = GetProcessListUniqueLock();
-    bool signal_debug_process_5x = kernelAbove500() && process->flags & 1;
+    bool signal_debug_process_5x = kernelAbove500() && process->flags & PROCESSFLAGS_NOTIFYWHENEXITED;
     /* Unregister with FS. */
     if (R_FAILED(fsprUnregisterProgram(process->pid))) {
         /* TODO: Panic. */
@@ -344,7 +344,7 @@ bool Registration::HasApplicationProcess(std::shared_ptr<Registration::Process> 
     auto auto_lock = GetProcessListUniqueLock();
     
     for (auto &process : g_process_list.processes) {
-        if (process->flags & 0x40) {
+        if (process->flags & PROCESSFLAGS_APPLICATION) {
             if (out != nullptr) {
                 *out = process;
             }
@@ -386,7 +386,7 @@ Result Registration::GetDebugProcessIds(u64 *out_pids, u32 max_out, u32 *num_out
     
 
     for (auto &process : g_process_list.processes) {
-        if (process->flags & 4 && num < max_out) {
+        if (process->flags & PROCESSFLAGS_CRASH_DEBUG && num < max_out) {
             out_pids[num++] = process->pid;
         }
     }
@@ -403,27 +403,33 @@ void Registration::GetProcessEventType(u64 *out_pid, u64 *out_type) {
     auto auto_lock = GetProcessListUniqueLock();
     
     for (auto &p : g_process_list.processes) {
-        if (kernelAbove200() && p->state >= ProcessState_DebugDetached && p->flags & 0x100) {
-            p->flags &= ~0x100;
+        if (kernelAbove200() && p->state >= ProcessState_DebugDetached && p->flags & PROCESSFLAGS_DEBUGDETACHED) {
+            p->flags &= ~PROCESSFLAGS_DEBUGDETACHED;
             *out_pid = p->pid;
-            *out_type = kernelAbove500() ? 2 : 5;
+            *out_type = kernelAbove500() ? PROCESSEVENTTYPE_500_DEBUGDETACHED : PROCESSEVENTTYPE_DEBUGDETACHED;
             return;
         }
-        if (p->flags & 0x10) {
+        if (p->flags & PROCESSFLAGS_DEBUGEVENTPENDING) {
             u64 old_flags = p->flags;
-            p->flags &= ~0x10;
+            p->flags &= ~PROCESSFLAGS_DEBUGEVENTPENDING;
             *out_pid = p->pid;
-            *out_type = kernelAbove500() ? (((old_flags >> 5) & 1) | 4) : (((old_flags >> 5) & 1) + 3);
+            *out_type = kernelAbove500() ?
+                ((old_flags & PROCESSFLAGS_DEBUGSUSPENDED) ?
+                    PROCESSEVENTTYPE_500_SUSPENDED :
+                    PROCESSEVENTTYPE_500_RUNNING) :
+                ((old_flags & PROCESSFLAGS_DEBUGSUSPENDED) ?
+                    PROCESSEVENTTYPE_SUSPENDED :
+                    PROCESSEVENTTYPE_RUNNING);
             return;
         }
-        if (p->flags & 2) {
+        if (p->flags & PROCESSFLAGS_CRASHED) {
             *out_pid = p->pid;
-            *out_type = kernelAbove500() ? 3 : 1;
+            *out_type = kernelAbove500() ? PROCESSEVENTTYPE_500_CRASH : PROCESSEVENTTYPE_CRASH;
             return;
         }
-        if (!kernelAbove500() && p->flags & 1 && p->state == ProcessState_Exited) {
+        if (!kernelAbove500() && p->flags & PROCESSFLAGS_NOTIFYWHENEXITED && p->state == ProcessState_Exited) {
             *out_pid = p->pid;
-            *out_type = 2;
+            *out_type = PROCESSEVENTTYPE_EXIT;
             return;
         }
     }
@@ -434,7 +440,7 @@ void Registration::GetProcessEventType(u64 *out_pid, u64 *out_type) {
             std::shared_ptr<Registration::Process> process = g_dead_process_list.processes[0];
             g_dead_process_list.processes.erase(g_dead_process_list.processes.begin());
             *out_pid = process->pid;
-            *out_type = 1;
+            *out_type = PROCESSEVENTTYPE_500_EXIT;
             return;
         }
     }

--- a/stratosphere/pm/source/pm_shell.cpp
+++ b/stratosphere/pm/source/pm_shell.cpp
@@ -140,7 +140,7 @@ std::tuple<Result> ShellService::clear_process_notification_flag(u64 pid) {
     
     std::shared_ptr<Registration::Process> proc = Registration::GetProcess(pid);
     if (proc != NULL) {
-        proc->flags &= ~2;
+        proc->flags &= ~PROCESSFLAGS_CRASHED;
         return {0x0};
     } else {
         return {0x20F};


### PR DESCRIPTION
This replaces the magic numbers used to interact with `Registration::Process.flags` with a set of enum constants. I would appreciate feedback on the names of these constants, as well as feedback on what to do about the notes I made when trying to figure out the meaning of each flag and event type. Should I keep the notes the way they are, remove them, or try to clean them up?

~~I would also appreciate if someone could verify that I didn't break any of the logic accidentally (probably by either accidentally replacing a flag with another one, or by changing the logic for flags 0x10 and 0x20), since I can't test on hardware at the moment.~~ Tested working on 3.0.0.