### PR TITLE
Add component overview to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@
 
 Atmosphère is a work-in-progress customized firmware for the Nintendo Switch.
 
+Components
+=====
+
+Atmosphère consists of multiple components, each of which replaces/modifies a different component of the system:
+
+* Fusée: First-stage Loader, responsible for loading and validating stage 2 (custom TrustZone) plus package2 (Kernel/FIRM sysmodules), and patching them as needed. This replaces all functionality normally in Package1loader/NX Bootloader.
+* Exosphère: Customized TrustZone, to run a customized Secure Monitor
+* Thermosphère: EL2 EmuNAND support, i.e. backing up and using virtualized/redirected NAND images
+* Stratosphère: Custom Sysmodule(s), both Rosalina style to extend the kernel/provide new features, and of the loader reimplementation style to hook important system actions
+* Troposphère: Application-level Horizon OS patches, used to implement desirable CFW features
+
 Credits
 =====
 


### PR DESCRIPTION
Loosely based on https://github.com/Atmosphere-NX/Atmosphere/projects - such an overview was really needed, and now the information is in the place where people will actually find it :)
