### PR TITLE
PM: add GetProcessHandle command to pm:dmnt

### DIFF
--- a/stratosphere/pm/source/pm_debug_monitor.cpp
+++ b/stratosphere/pm/source/pm_debug_monitor.cpp
@@ -24,6 +24,9 @@ Result DebugMonitorService::dispatch(IpcParsedCommand &r, IpcCommand &out_c, u64
             case Dmnt_Cmd_5X_EnableDebugForApplication:
                 rc = WrapIpcCommandImpl<&DebugMonitorService::enable_debug_for_application>(this, r, out_c, pointer_buffer, pointer_buffer_size);
                 break;
+            case Dmnt_Cmd_5X_AtmosphereGetProcessHandle:
+                rc = WrapIpcCommandImpl<&DebugMonitorService::get_process_handle>(this, r, out_c, pointer_buffer, pointer_buffer_size);
+                break;
             default:
                 break;
         }
@@ -49,6 +52,9 @@ Result DebugMonitorService::dispatch(IpcParsedCommand &r, IpcCommand &out_c, u64
                 break;
             case Dmnt_Cmd_EnableDebugForApplication:
                 rc = WrapIpcCommandImpl<&DebugMonitorService::enable_debug_for_application>(this, r, out_c, pointer_buffer, pointer_buffer_size);
+                break;
+            case Dmnt_Cmd_AtmosphereGetProcessHandle:
+                rc = WrapIpcCommandImpl<&DebugMonitorService::get_process_handle>(this, r, out_c, pointer_buffer, pointer_buffer_size);
                 break;
             default:
                 break;
@@ -116,4 +122,12 @@ std::tuple<Result, CopiedHandle> DebugMonitorService::enable_debug_for_applicati
     Handle h = 0;
     Result rc = Registration::EnableDebugForApplication(&h);
     return {rc, h};
+}
+
+std::tuple<Result, CopiedHandle> DebugMonitorService::get_process_handle(u64 pid) {
+    Registration::Process *proc = Registration::GetProcess(pid);
+    if(proc == NULL) {
+        return {0x20F, 0};
+    }
+    return {0, proc->handle};
 }

--- a/stratosphere/pm/source/pm_debug_monitor.hpp
+++ b/stratosphere/pm/source/pm_debug_monitor.hpp
@@ -12,6 +12,8 @@ enum DmntCmd {
     Dmnt_Cmd_EnableDebugForTitleId = 4,
     Dmnt_Cmd_GetApplicationProcessId = 5,
     Dmnt_Cmd_EnableDebugForApplication = 6,
+
+    Dmnt_Cmd_AtmosphereGetProcessHandle = 65000
 };
 
 enum DmntCmd_5X {
@@ -21,6 +23,8 @@ enum DmntCmd_5X {
     Dmnt_Cmd_5X_EnableDebugForTitleId = 3,
     Dmnt_Cmd_5X_GetApplicationProcessId = 4,
     Dmnt_Cmd_5X_EnableDebugForApplication = 5,
+
+    Dmnt_Cmd_5X_AtmosphereGetProcessHandle = 65000
 };
 
 class DebugMonitorService final : IServiceObject {
@@ -37,4 +41,7 @@ class DebugMonitorService final : IServiceObject {
         std::tuple<Result, CopiedHandle> enable_debug_for_tid(u64 tid);
         std::tuple<Result, u64> get_application_process_id();
         std::tuple<Result, CopiedHandle> enable_debug_for_application();
+
+        /* Atmosphere commands. */
+        std::tuple<Result, CopiedHandle> get_process_handle(u64 pid);
 };


### PR DESCRIPTION
Adds a command to `pm:dmnt` to obtain a process handle from PID. Tested working on 3.0.0.