### PR TITLE
SM: Add compile-time option to put a lower bound on session limits

### DIFF
--- a/stratosphere/sm/Makefile
+++ b/stratosphere/sm/Makefile
@@ -34,7 +34,7 @@ ARCH	:=	-march=armv8-a -mtune=cortex-a57 -mtp=soft -fPIE
 CFLAGS	:=	-g -Wall -O2 -ffunction-sections \
 			$(ARCH) $(DEFINES)
 
-CFLAGS	+=	$(INCLUDE) -D__SWITCH__ -DSM_ENABLE_SMHAX -DSM_ENABLE_MITM
+CFLAGS	+=	$(INCLUDE) -D__SWITCH__ -DSM_ENABLE_SMHAX -DSM_ENABLE_MITM -DSM_MINIMUM_SESSION_LIMIT=8
 
 CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++17
 

--- a/stratosphere/sm/source/sm_registration.cpp
+++ b/stratosphere/sm/source/sm_registration.cpp
@@ -252,6 +252,12 @@ Result Registration::RegisterServiceForPid(u64 pid, u64 service, u64 max_session
         return 0x815;
     }
     
+#ifdef SM_MINIMUM_SESSION_LIMIT
+    if (max_sessions < SM_MINIMUM_SESSION_LIMIT) {
+        max_sessions = SM_MINIMUM_SESSION_LIMIT;
+    }
+#endif
+
     Registration::Service *free_service = GetFreeService();
     if (free_service == NULL) {
         return 0xA15;
@@ -288,6 +294,12 @@ Result Registration::RegisterServiceForSelf(u64 service, u64 max_sessions, bool 
     if (HasService(service)) {
         return 0x815;
     }
+
+#ifdef SM_MINIMUM_SESSION_LIMIT
+    if (max_sessions < SM_MINIMUM_SESSION_LIMIT) {
+        max_sessions = SM_MINIMUM_SESSION_LIMIT;
+    }
+#endif
     
     Registration::Service *free_service = GetFreeService();
     if (free_service == NULL) {


### PR DESCRIPTION
This lets us do things like accessing `fsp-ldr` without having to kill `ldr`. The default I chose is 8.

Tested working on 3.0.0.