### PR TITLE
fusee: Run periodic autocal only on the uSD controller

### DIFF
--- a/fusee/fusee-primary/src/sdmmc.c
+++ b/fusee/fusee-primary/src/sdmmc.c
@@ -2175,7 +2175,10 @@ static int sdmmc_send_command(struct mmc *mmc, enum sdmmc_command command,
         }
     }
 
-    sdmmc_run_autocal(mmc, true);
+    // Periodically recalibrate the SD controller
+    if (mmc->controller == SWITCH_MICROSD) {
+        sdmmc_run_autocal(mmc, true);
+    }
 
     // If we have data to send, prepare it.
     sdmmc_prepare_command_data(mmc, blocks_to_transfer, is_write, auto_terminate, mmc->use_dma, argument);

--- a/fusee/fusee-secondary/src/sdmmc.c
+++ b/fusee/fusee-secondary/src/sdmmc.c
@@ -2176,7 +2176,10 @@ static int sdmmc_send_command(struct mmc *mmc, enum sdmmc_command command,
         }
     }
 
-    sdmmc_run_autocal(mmc, true);
+    // Periodically recalibrate the SD controller
+    if (mmc->controller == SWITCH_MICROSD) {
+        sdmmc_run_autocal(mmc, true);
+    }
 
     // If we have data to send, prepare it.
     sdmmc_prepare_command_data(mmc, blocks_to_transfer, is_write, auto_terminate, mmc->use_dma, argument);


### PR DESCRIPTION
As per TRM, periodic autocalibration should only be run on the uSD controllers. Given only SDMMC1 is relevant on the switch, limit it to this controller.