### PR TITLE
fusee: Allow declaring yourself knowledgeable via an environment variable

### DIFF
--- a/fusee/fusee-primary/Makefile
+++ b/fusee/fusee-primary/Makefile
@@ -28,6 +28,10 @@ INCLUDES	:=	include
 ARCH	:=	-march=armv4t -mtune=arm7tdmi -mthumb -mthumb-interwork
 DEFINES :=	-D__BPMP__ -DFUSEE_STAGE1_SRC
 
+ifeq ($(FUSEE_I_KNOW_WHAT_I_AM_DOING),1)
+DEFINES +=	-DI_KNOW_WHAT_I_AM_DOING
+endif
+
 CFLAGS	:= \
 	-g \
 	-O2 \


### PR DESCRIPTION
I couldn't find any method of declaring myself knowledgeable without dirtying the git working directory, which makes rebases a pain (among other things git refuses to do with a dirty tree).

This change allows compiling things without having to modify the source files or Makefiles.

Tested build with:
* NEW_ENV_VAR=1 make, build passes as expected
* NEW_ENV_VAR=0 make, build fails as expected
* (NEW_ENV_VAR unset) make, build fails as expected
