### PR TITLE
Define wait() in fusee-primary/secondary

### DIFF
--- a/fusee/fusee-primary/src/utils.c
+++ b/fusee/fusee-primary/src/utils.c
@@ -13,6 +13,13 @@
 
 #include <inttypes.h>
 
+void wait(uint32_t microseconds) {
+    uint32_t old_time = TIMERUS_CNTR_1US_0;
+    while (TIMERUS_CNTR_1US_0 - old_time <= microseconds) {
+        /* Spin-lock. */
+    }
+}
+
 __attribute__((noreturn)) void watchdog_reboot(void) {
     volatile watchdog_timers_t *wdt = GET_WDT(4);
     wdt->PATTERN = WDT_REBOOT_PATTERN;

--- a/fusee/fusee-secondary/src/utils.c
+++ b/fusee/fusee-secondary/src/utils.c
@@ -12,6 +12,13 @@
 #include <stdio.h>
 #include <inttypes.h>
 
+void wait(uint32_t microseconds) {
+    uint32_t old_time = TIMERUS_CNTR_1US_0;
+    while (TIMERUS_CNTR_1US_0 - old_time <= microseconds) {
+        /* Spin-lock. */
+    }
+}
+
 __attribute__((noreturn)) void watchdog_reboot(void) {
     volatile watchdog_timers_t *wdt = GET_WDT(4);
     wdt->PATTERN = WDT_REBOOT_PATTERN;


### PR DESCRIPTION
fusee-primary and secondary were linking to sys/wait.h, which didn't quite work :slightly_smiling_face: 

Unrelated: I'm noticing (on my 4.0.1 system) exosphere's bootup_misc_mmio is freezing the fusee-secondary. I can add a panic before `sync_with_nx_bootloader(NX_BOOTLOADER_STATE_FINISHED_4X);` to verify that exosphere continues execution, but fusee-secondary freezes before it can get `SECMON_AWAKE`. Not sure how I can help debug further, or if this is already known.