### PR TITLE
fusee-secondary: Correct else-if condition in xmemmove()

### DIFF
--- a/fusee/fusee-secondary/src/chainloader.c
+++ b/fusee/fusee-secondary/src/chainloader.c
@@ -17,7 +17,7 @@ static void *xmemmove(void *dst, const void *src, size_t len)
         for (size_t i = 0; i < len; i++) {
             dst8[i] = src8[i];
         }
-    } else if (src8 > dst8) {
+    } else if (dst8 > src8) {
         for (size_t i = len; len > 0; len--)
             dst8[i - 1] = src8[i - 1];
     }


### PR DESCRIPTION
Previously both the if and else conditions were the same.

Probably needs an extra set of eyes on this, just to ensure the right branch is being changed here.