### PR TITLE
added unhandled case and preconditions when using svcWaitSynchronization

### DIFF
--- a/stratosphere/libstratosphere/source/multithreadedwaitablemanager.cpp
+++ b/stratosphere/libstratosphere/source/multithreadedwaitablemanager.cpp
@@ -42,6 +42,12 @@ IWaitable *MultiThreadedWaitableManager::get_waitable() {
         handles.resize(this->waitables.size());
         std::transform(this->waitables.begin(), this->waitables.end(), handles.begin(), [](IWaitable *w) { return w->get_handle(); });
         
+        if(this->waitables.size() == 0) {
+            continue;
+        }
+        if(this->waitables.size() > 0x40) {
+            /* TODO: panic. Too many waitables */
+        }
         rc = svcWaitSynchronization(&handle_index, handles.data(), this->waitables.size(), this->timeout);
         IWaitable *w = this->waitables[handle_index];
         if (R_SUCCEEDED(rc)) {
@@ -50,7 +56,20 @@ IWaitable *MultiThreadedWaitableManager::get_waitable() {
         } else if (rc == 0xEA01) {
             /* Timeout. */
             std::for_each(waitables.begin(), waitables.end(), std::mem_fn(&IWaitable::update_priority));
-        } else if (rc != 0xF601 && rc != 0xE401) {
+        } else if (rc == 0xE401) {
+            /* Invalid handle */
+            /* handle_index does not get updated when this happens 
+            so we don't know which waitable is the problem.
+            However switchbrew says that svcWaitSynchronization
+            does not accept 0xFFFF8001 or 0xFFFF8000 as handles
+            so we could at least remove them if any exists */
+            
+            for(auto it = waitables.begin(); it != waitables.end(); it++) {
+                if((*it)->get_handle() == 0xFFFF8000 || (*it)->get_handle() == 0xFFFF8001) {
+                    waitables.erase(it);
+                }
+            }
+        } else if (rc != 0xF601) {
             /* TODO: Panic. When can this happen? */
         } else {
             std::for_each(waitables.begin(), waitables.begin() + handle_index, std::mem_fn(&IWaitable::update_priority));

--- a/stratosphere/libstratosphere/source/waitablemanager.cpp
+++ b/stratosphere/libstratosphere/source/waitablemanager.cpp
@@ -39,7 +39,7 @@ void WaitableManager::process_internal(bool break_on_timeout) {
             continue;
         }
         if(this->waitables.size() > 0x40) {
-            panic("PANIC: Too many waitables in waitablemanager");
+            /* TODO: panic. Too many waitables */
         }
         rc = svcWaitSynchronization(&handle_index, handles.data(), this->waitables.size(), this->timeout);
         if (R_SUCCEEDED(rc)) {
@@ -58,22 +58,18 @@ void WaitableManager::process_internal(bool break_on_timeout) {
         } else if (rc == 0xE401) {
             /* Invalid handle */
             /* handle_index does not get updated when this happens 
-            so we can't really do anything */
-            panic("PANIC: Invalid handle in waitablemanager");
-
-            /* however switchbrew says that svcWaitSynchronization
+            so we don't know which waitable is the problem.
+            However switchbrew says that svcWaitSynchronization
             does not accept 0xFFFF8001 or 0xFFFF8000 as handles
-            so we could at least remove them if any exists
+            so we could at least remove them if any exists */
             
             for(auto it = waitables.begin(); it != waitables.end(); it++) {
                 if(*it->get_handle() == 0xFFFF8000 || *it->get_handle() == 0xFFFF8001) {
                     waitables.erase(it);
                 }
             }
-            */
         } else if (rc != 0xF601) {
-            /* TODO: When can this happen? */
-            panic("PANIC: unhandled result code in waitablemanager");
+            /* TODO: panic. When can this happen? */
         }
         
         if (rc == 0xF601) {

--- a/stratosphere/libstratosphere/source/waitablemanager.cpp
+++ b/stratosphere/libstratosphere/source/waitablemanager.cpp
@@ -64,7 +64,7 @@ void WaitableManager::process_internal(bool break_on_timeout) {
             so we could at least remove them if any exists */
             
             for(auto it = waitables.begin(); it != waitables.end(); it++) {
-                if(*it->get_handle() == 0xFFFF8000 || *it->get_handle() == 0xFFFF8001) {
+                if((*it)->get_handle() == 0xFFFF8000 || (*it)->get_handle() == 0xFFFF8001) {
                     waitables.erase(it);
                 }
             }


### PR DESCRIPTION
Not tested but should work.

According to switchbrew docs, svcWaitSynchronization works with num_handles <= 0x40 and throws an error on num_handles == 0, so we need to check that.

Also it does not accept 0xFFFF8001 or 0xFFFF8000 as handles, so if we have an invalid one we need to get rid of the waitable or panic.