### PR TITLE
fusee-primary: Fix always false conditional in xmemmove

### DIFF
--- a/fusee/fusee-primary/src/chainloader.c
+++ b/fusee/fusee-primary/src/chainloader.c
@@ -17,7 +17,7 @@ static void *xmemmove(void *dst, const void *src, size_t len)
         for (size_t i = 0; i < len; i++) {
             dst8[i] = src8[i];
         }
-    } else if (src8 > dst8) {
+    } else if (dst8 > src8) {
         for (size_t i = len; len > 0; len--)
             dst8[i - 1] = src8[i - 1];
     }


### PR DESCRIPTION
This was corrected in 4b8455baf91d8699a663341c135c91c34f0a7816 for fusee-secondary, but I neglected to also fix it in fusee-primary (my bad!)