### PR TITLE
fusee-primary/sdram: Correct setting of the PMC DDR_PWR register

### DIFF
--- a/fusee/fusee-primary/src/sdram.c
+++ b/fusee/fusee-primary/src/sdram.c
@@ -549,7 +549,7 @@ void sdram_init()
     pmc->vddp_sel = params->pmc_vddp_sel;
     udelay(params->pmc_vddp_sel_wait);
     
-    pmc->ddr_pwr = pmc->ddr_pwr;
+    pmc->ddr_pwr = params->pmc_ddr_pwr;
     pmc->no_iopower = params->pmc_no_io_power;
     pmc->reg_short = params->pmc_reg_short;
     pmc->ddr_cntrl = params->pmc_ddr_ctrl;


### PR DESCRIPTION
Previously this was just assigning the value it already contains to itself, as opposed to whatever the parameters were dictating for it. It's also worth noting that [other](https://chromium.googlesource.com/chromiumos/third_party/coreboot/+/firmware-nyan-5771.B/src/soc/nvidia/tegra124/sdram.c#52) [boards](https://github.com/rockchip-linux/coreboot/blob/adde3eaa806577cbb7b2e0c702740a8da9e32255/src/soc/nvidia/tegra132/sdram.c#L479) derive the contents of the register off the parameters, so I'm inclined to think this was just a mistaken assignment.