### PR TITLE
fusee: Fix a compiler warning

### DIFF
--- a/fusee/fusee-primary/src/lib/lz.c
+++ b/fusee/fusee-primary/src/lib/lz.c
@@ -188,7 +188,7 @@ static int _LZ_ReadVarSize( unsigned int * x, const unsigned char * buf )
 * The function returns the size of the compressed data.
 *************************************************************************/
 
-int LZ_Compress( const unsigned char *in, unsigned char *out, unsigned int insize )
+int LZ_Compress( unsigned char *in, unsigned char *out, unsigned int insize )
 {
     unsigned char marker, symbol;
     unsigned int  inpos, outpos, bytesleft, i;


### PR DESCRIPTION
As of the 6.0.0 fusee support commit (f864b08), Atmosphere builds fail:

```
arm-none-eabi-gcc -MMD -MP -MF /home/ao/Projects/Atmosphere/fusee/fusee-primary/build/lz.d -g -O2 -fomit-frame-pointer -ffunction-sections -fdata-sections -std=gnu11 -Werror -Wall -fstrict-volatile-bitfields -march=armv4t -mtune=arm7tdmi -mthumb -mthumb-interwork -D__BPMP__ -DFUSEE_STAGE1_SRC -I/home/ao/Projects/Atmosphere/fusee/fusee-primary/include  -I/home/ao/Projects/Atmosphere/fusee/fusee-primary/build -c /home/ao/Projects/Atmosphere/fusee/fusee-primary/src/lib/lz.c -o lz.o
/home/ao/Projects/Atmosphere/fusee/fusee-primary/src/lib/lz.c: In function 'LZ_Compress':
/home/ao/Projects/Atmosphere/fusee/fusee-primary/src/lib/lz.c:242:14: error: assignment discards 'const' qualifier from pointer target type [-Werror=discarded-qualifiers]
         ptr1 = &in[ inpos ];
              ^
cc1: all warnings being treated as errors
/opt/devkitpro/devkitARM/base_rules:84: recipe for target 'lz.o' failed
make[1]: *** [lz.o] Error 1
Makefile:110: recipe for target 'build' failed
make: *** [build] Error 2
```

This PR removes `const` from `*in`, fixing the warning (and builds) while maintaining functionality.

This might not be the best way to do it, but it works.