### PR TITLE
loader: add SetExtraMemory extension

### DIFF
--- a/docs/modules/loader.md
+++ b/docs/modules/loader.md
@@ -62,3 +62,15 @@ TODO
 ### SM MITM Integration
 
 When the Stratosphere implementation of loader creates a new process, it notifies [sm](sm.md) through the `AtmosphereAssociatePidTidForMitm` command to notify any MITM services of new processes' identities.
+
+### IPC: AtmosphereSetExtraMemory
+
+This command is added to the [`ldr:shel`](https://reswitched.github.io/SwIPC/ifaces.html#nn::ro::detail::ILdrShellInterface) interface, and allows a client to request that a title be created with a certain amount of additional CodeStatic memory the next time it is created. This is useful for advanced homebrew loaders.
+
+The SwIPC definition for this command follows.
+```
+interface nn::ldr::detail::ILdrShellInterface is ldr:shel {
+  ...
+  [65000] AtmosphereSetExtraMemory(u64 title_id, u64 extra_memory_size);
+}
+```

--- a/stratosphere/loader/source/ldr_launch_queue.hpp
+++ b/stratosphere/loader/source/ldr_launch_queue.hpp
@@ -39,4 +39,8 @@ class LaunchQueue {
         static int get_free_index(u64 tid);
         static bool contains(u64 tid);
         static void clear();
+
+        // extra memory extension
+        static void set_extra_memory(u64 tid, u64 extra_size);
+        static u64 get_extra_memory(u64 tid);
 };

--- a/stratosphere/loader/source/ldr_process_creation.cpp
+++ b/stratosphere/loader/source/ldr_process_creation.cpp
@@ -172,6 +172,11 @@ Result ProcessCreation::CreateProcess(Handle *out_process_h, u64 index, char *nc
     if (R_FAILED(rc)) {
         goto CREATE_PROCESS_END;
     }
+
+    nso_extents.total_size += 0xFFF;
+    nso_extents.total_size &= ~0xFFFULL;
+
+    nso_extents.total_size += LaunchQueue::get_extra_memory(target_process->tid_sid.title_id);
     
     /* Set Address Space information in ProcessInfo. */
     process_info.code_addr = nso_extents.base_address;

--- a/stratosphere/loader/source/ldr_shell.cpp
+++ b/stratosphere/loader/source/ldr_shell.cpp
@@ -30,6 +30,9 @@ Result ShellService::dispatch(IpcParsedCommand &r, IpcCommand &out_c, u64 cmd_id
         case Shell_Cmd_ClearLaunchQueue:
             rc = WrapIpcCommandImpl<&ShellService::clear_launch_queue>(this, r, out_c, pointer_buffer, pointer_buffer_size);
             break;
+        case Shell_Cmd_AtmosphereSetExtraMemory:
+            rc = WrapIpcCommandImpl<&ShellService::set_extra_memory>(this, r, out_c, pointer_buffer, pointer_buffer_size);
+            break;
         default:
             break;
     }
@@ -44,5 +47,11 @@ std::tuple<Result> ShellService::add_title_to_launch_queue(u64 args_size, u64 ti
 std::tuple<Result> ShellService::clear_launch_queue(u64 dat) {
     fprintf(stderr, "Clear launch queue: %lx\n", dat);
     LaunchQueue::clear();
+    return {0};
+}
+
+std::tuple<Result> ShellService::set_extra_memory(u64 tid, u64 extra_size) {
+    fprintf(stderr, "Set extra memory for %zX: %zX\n", tid, extra_size);
+    LaunchQueue::set_extra_memory(tid, extra_size);
     return {0};
 }

--- a/stratosphere/loader/source/ldr_shell.hpp
+++ b/stratosphere/loader/source/ldr_shell.hpp
@@ -20,7 +20,9 @@
 
 enum ShellServiceCmd {
     Shell_Cmd_AddTitleToLaunchQueue = 0,
-    Shell_Cmd_ClearLaunchQueue = 1
+    Shell_Cmd_ClearLaunchQueue = 1,
+
+    Shell_Cmd_AtmosphereSetExtraMemory = 65000,
 };
 
 class ShellService final : public IServiceObject {
@@ -39,4 +41,7 @@ class ShellService final : public IServiceObject {
         /* Actual commands. */
         std::tuple<Result> add_title_to_launch_queue(u64 args_size, u64 tid, InPointer<char> args);
         std::tuple<Result> clear_launch_queue(u64 dat);
+
+        /* Atmosphere commands. */
+        std::tuple<Result> set_extra_memory(u64 tid, u64 extra_size);
 };


### PR DESCRIPTION
Adds a command to `ldr:shel` to make it so the next time a specific title is loaded, it will have extra code pages that loader leaves alone. Twili (misson20000/twili#52) uses these extra code pages to load an NRO. If anyone else ever wants to implement a multiprocess homebrew loader, this will probably work for that, too.

Tested on 5.0.0.