### PR TITLE
Make sure a title has fs mitm mods/files on the SD before enabling

### DIFF
--- a/stratosphere/fs_mitm/source/fsmitm_service.hpp
+++ b/stratosphere/fs_mitm/source/fsmitm_service.hpp
@@ -38,7 +38,14 @@ class FsMitMService : public IMitMServiceObject {
         }
         
         static bool should_mitm(u64 pid, u64 tid) {
-            return tid >= 0x0100000000010000ULL || Utils::HasSdMitMFlag(tid);
+            if(!(tid >= 0x0100000000010000ULL || Utils::HasSdMitMFlag(tid))) return false;
+            
+            FsDir tst;
+            char slash = '/';
+            bool ret = R_SUCCEEDED(Utils::OpenSdDirForAtmosphere(tid, &slash, &tst));
+            if(!ret) return false;
+            fsDirClose(&tst);
+            return true;
         }
         
         FsMitMService *clone() override {


### PR DESCRIPTION
This is a temporary workaround for #202, and the code is taken from Rei's fork of Stratosphere, seen here: https://github.com/Reisyukaku/NX_Sysmodules/blob/3c12add04883b893698cfa04451c834e34bcbe66/fs_mitm/source/fsmitm_service.hpp#L24-L33