### PR TITLE
loader: add SetExternalContentSource extension

### DIFF
--- a/stratosphere/loader/source/ldr_content_management.cpp
+++ b/stratosphere/loader/source/ldr_content_management.cpp
@@ -56,7 +56,7 @@ Result ContentManagement::MountCode(u64 tid, FsStorageId sid) {
         RefreshConfigurationData();
     }
     
-    if (ShouldOverrideContents() && R_SUCCEEDED(MountCodeNspOnSd(tid))) {
+    if (ShouldOverrideContents(tid) && R_SUCCEEDED(MountCodeNspOnSd(tid))) {
         return 0x0;
     }
         
@@ -302,7 +302,7 @@ bool ContentManagement::ShouldReplaceWithHBL(u64 tid) {
     return g_mounted_hbl_nsp && tid == g_override_hbl_tid;
 }
 
-bool ContentManagement::ShouldOverrideContents() {
+bool ContentManagement::ShouldOverrideContents(u64 tid) {
     if (HasCreatedTitle(0x0100000000001000)) {
         u64 kDown = 0;
         bool keys_triggered = (R_SUCCEEDED(HidManagement::GetKeysDown(&kDown)) && ((kDown & g_override_key_combination) != 0));

--- a/stratosphere/loader/source/ldr_content_management.hpp
+++ b/stratosphere/loader/source/ldr_content_management.hpp
@@ -38,5 +38,5 @@ class ContentManagement {
         static void TryMountSdCard();
         
         static bool ShouldReplaceWithHBL(u64 tid);
-        static bool ShouldOverrideContents();
+        static bool ShouldOverrideContents(u64 tid);
 };

--- a/stratosphere/loader/source/ldr_content_management.hpp
+++ b/stratosphere/loader/source/ldr_content_management.hpp
@@ -39,4 +39,24 @@ class ContentManagement {
         
         static bool ShouldReplaceWithHBL(u64 tid);
         static bool ShouldOverrideContents(u64 tid);
+
+        /* SetExternalContentSource extension */
+        class ExternalContentSource {
+            public:
+                static void GenerateMountpointName(u64 tid, char *out, size_t max_length);
+
+                ExternalContentSource(u64 tid, const char *mountpoint);
+                ~ExternalContentSource();
+
+                ExternalContentSource(const ExternalContentSource &other) = delete;
+                ExternalContentSource(ExternalContentSource &&other) = delete;
+                ExternalContentSource &operator=(const ExternalContentSource &other) = delete;
+                ExternalContentSource &operator=(ExternalContentSource &&other) = delete;
+
+                const u64 tid;
+                char mountpoint[32];
+        };
+        static ExternalContentSource *GetExternalContentSource(u64 tid); /* returns nullptr if no ECS is set */
+        static Result SetExternalContentSource(u64 tid, FsFileSystem filesystem); /* takes ownership of filesystem */
+        static void ClearExternalContentSource(u64 tid);
 };

--- a/stratosphere/loader/source/ldr_npdm.cpp
+++ b/stratosphere/loader/source/ldr_npdm.cpp
@@ -53,7 +53,7 @@ FILE *NpdmUtils::OpenNpdmFromSdCard(u64 title_id) {
 
 
 FILE *NpdmUtils::OpenNpdm(u64 title_id) {
-    if (ContentManagement::ShouldOverrideContents()) {
+    if (ContentManagement::ShouldOverrideContents(title_id)) {
         if (ContentManagement::ShouldReplaceWithHBL(title_id)) {
             return OpenNpdmFromHBL();
         }
@@ -182,7 +182,7 @@ Result NpdmUtils::LoadNpdm(u64 tid, NpdmInfo *out) {
     info->acid->title_id_range_max = tid;
     info->aci0->title_id = tid;
     
-    if (ContentManagement::ShouldOverrideContents() && ContentManagement::ShouldReplaceWithHBL(tid) 
+    if (ContentManagement::ShouldOverrideContents(tid) && ContentManagement::ShouldReplaceWithHBL(tid) 
         && R_SUCCEEDED(LoadNpdmInternal(OpenNpdmFromExeFS(), &g_original_npdm_cache))) {
         NpdmInfo *original_info = &g_original_npdm_cache.info;
         /* Fix pool partition. */

--- a/stratosphere/loader/source/ldr_npdm.cpp
+++ b/stratosphere/loader/source/ldr_npdm.cpp
@@ -501,3 +501,9 @@ u32 NpdmUtils::GetApplicationTypeRaw(u32 *caps, size_t num_caps) {
     }
     return application_type;
 }
+
+void NpdmUtils::InvalidateCache(u64 tid) {
+    if (g_npdm_cache.info.title_id == tid) {
+        g_npdm_cache.info = (const NpdmUtils::NpdmInfo){0};
+    }
+}

--- a/stratosphere/loader/source/ldr_npdm.cpp
+++ b/stratosphere/loader/source/ldr_npdm.cpp
@@ -33,6 +33,12 @@ Result NpdmUtils::LoadNpdmFromCache(u64 tid, NpdmInfo *out) {
     return 0;
 }
 
+FILE *NpdmUtils::OpenNpdmFromECS(ContentManagement::ExternalContentSource *ecs) {
+    std::fill(g_npdm_path, g_npdm_path + FS_MAX_PATH, 0);
+    snprintf(g_npdm_path, FS_MAX_PATH, "%s:/main.npdm", ecs->mountpoint);
+    return fopen(g_npdm_path, "rb");
+}
+
 FILE *NpdmUtils::OpenNpdmFromHBL() {
     std::fill(g_npdm_path, g_npdm_path + FS_MAX_PATH, 0);
     snprintf(g_npdm_path, FS_MAX_PATH, "hbl:/main.npdm");
@@ -53,6 +59,11 @@ FILE *NpdmUtils::OpenNpdmFromSdCard(u64 title_id) {
 
 
 FILE *NpdmUtils::OpenNpdm(u64 title_id) {
+    ContentManagement::ExternalContentSource *ecs = nullptr;
+    if ((ecs = ContentManagement::GetExternalContentSource(title_id)) != nullptr) {
+        return OpenNpdmFromECS(ecs);
+    }
+
     if (ContentManagement::ShouldOverrideContents(title_id)) {
         if (ContentManagement::ShouldReplaceWithHBL(title_id)) {
             return OpenNpdmFromHBL();

--- a/stratosphere/loader/source/ldr_npdm.hpp
+++ b/stratosphere/loader/source/ldr_npdm.hpp
@@ -19,6 +19,7 @@
 #include <cstdio>
 
 #include "ldr_registration.hpp"
+#include "ldr_content_management.hpp" /* for ExternalContentSource */
 
 #define MAGIC_META 0x4154454D
 #define MAGIC_ACI0 0x30494341
@@ -101,7 +102,7 @@ class NpdmUtils {
         static Result ValidateCapabilityAgainstRestrictions(u32 *restrict_caps, size_t num_restrict_caps, u32 *&cur_cap, size_t &caps_remaining);
         static Result ValidateCapabilities(u32 *acid_caps, size_t num_acid_caps, u32 *aci0_caps, size_t num_aci0_caps);
         
-        
+        static FILE *OpenNpdmFromECS(ContentManagement::ExternalContentSource *ecs);
         static FILE *OpenNpdmFromHBL();
         static FILE *OpenNpdmFromExeFS();
         static FILE *OpenNpdmFromSdCard(u64 tid);

--- a/stratosphere/loader/source/ldr_npdm.hpp
+++ b/stratosphere/loader/source/ldr_npdm.hpp
@@ -108,6 +108,8 @@ class NpdmUtils {
         static FILE *OpenNpdm(u64 tid);
         static Result LoadNpdm(u64 tid, NpdmInfo *out);
         static Result LoadNpdmFromCache(u64 tid, NpdmInfo *out);
+
+        static void InvalidateCache(u64 tid);
     private:
         static Result LoadNpdmInternal(FILE *f_npdm, NpdmCache *cache);
 };

--- a/stratosphere/loader/source/ldr_nso.cpp
+++ b/stratosphere/loader/source/ldr_nso.cpp
@@ -61,7 +61,7 @@ bool NsoUtils::CheckNsoStubbed(unsigned int index, u64 title_id) {
 }
 
 FILE *NsoUtils::OpenNso(unsigned int index, u64 title_id) {
-    if (ContentManagement::ShouldOverrideContents()) {
+    if (ContentManagement::ShouldOverrideContents(title_id)) {
         if (ContentManagement::ShouldReplaceWithHBL(title_id)) {
             return OpenNsoFromHBL(index);
         }

--- a/stratosphere/loader/source/ldr_nso.cpp
+++ b/stratosphere/loader/source/ldr_nso.cpp
@@ -31,6 +31,12 @@ static bool g_nso_present[NSO_NUM_MAX] = {0};
 
 static char g_nso_path[FS_MAX_PATH] = {0};
 
+FILE *NsoUtils::OpenNsoFromECS(unsigned int index, ContentManagement::ExternalContentSource *ecs) {
+    std::fill(g_nso_path, g_nso_path + FS_MAX_PATH, 0);
+    snprintf(g_nso_path, FS_MAX_PATH, "%s:/%s", ecs->mountpoint, NsoUtils::GetNsoFileName(index));
+    return fopen(g_nso_path, "rb");
+}
+
 FILE *NsoUtils::OpenNsoFromHBL(unsigned int index) {
     std::fill(g_nso_path, g_nso_path + FS_MAX_PATH, 0);
     snprintf(g_nso_path, FS_MAX_PATH, "hbl:/%s", NsoUtils::GetNsoFileName(index));
@@ -61,6 +67,11 @@ bool NsoUtils::CheckNsoStubbed(unsigned int index, u64 title_id) {
 }
 
 FILE *NsoUtils::OpenNso(unsigned int index, u64 title_id) {
+    ContentManagement::ExternalContentSource *ecs = nullptr;
+    if ((ecs = ContentManagement::GetExternalContentSource(title_id)) != nullptr) {
+        return OpenNsoFromECS(index, ecs);
+    }
+
     if (ContentManagement::ShouldOverrideContents(title_id)) {
         if (ContentManagement::ShouldReplaceWithHBL(title_id)) {
             return OpenNsoFromHBL(index);

--- a/stratosphere/loader/source/ldr_nso.hpp
+++ b/stratosphere/loader/source/ldr_nso.hpp
@@ -18,6 +18,8 @@
 #include <switch.h>
 #include <cstdio>
 
+#include "ldr_content_management.hpp" /* for ExternalContentSource */
+
 #define MAGIC_NSO0 0x304F534E
 #define NSO_NUM_MAX 13
 
@@ -96,7 +98,8 @@ class NsoUtils {
                     return "?";
             }
         }
-        
+
+        static FILE *OpenNsoFromECS(unsigned int index, ContentManagement::ExternalContentSource *ecs);
         static FILE *OpenNsoFromHBL(unsigned int index);
         static FILE *OpenNsoFromExeFS(unsigned int index);
         static FILE *OpenNsoFromSdCard(unsigned int index, u64 title_id);

--- a/stratosphere/loader/source/ldr_process_creation.cpp
+++ b/stratosphere/loader/source/ldr_process_creation.cpp
@@ -215,6 +215,8 @@ Result ProcessCreation::CreateProcess(Handle *out_process_h, u64 index, char *nc
     
     rc = 0;  
 CREATE_PROCESS_END:
+    /* ECS is a one-shot operation. */
+    ContentManagement::ClearExternalContentSource(target_process->tid_sid.title_id);
     if (mounted_code) {
         if (R_SUCCEEDED(rc) && target_process->tid_sid.storage_id != FsStorageId_None) {
             rc = ContentManagement::UnmountCode();

--- a/stratosphere/loader/source/ldr_shell.hpp
+++ b/stratosphere/loader/source/ldr_shell.hpp
@@ -20,7 +20,9 @@
 
 enum ShellServiceCmd {
     Shell_Cmd_AddTitleToLaunchQueue = 0,
-    Shell_Cmd_ClearLaunchQueue = 1
+    Shell_Cmd_ClearLaunchQueue = 1,
+
+    Shell_Cmd_AtmosphereSetExternalContentSource = 65000,
 };
 
 class ShellService final : public IServiceObject {
@@ -39,4 +41,7 @@ class ShellService final : public IServiceObject {
         /* Actual commands. */
         std::tuple<Result> add_title_to_launch_queue(u64 args_size, u64 tid, InPointer<char> args);
         std::tuple<Result> clear_launch_queue(u64 dat);
+
+        /* Atmosphere commands. */
+        std::tuple<Result, MovedHandle> set_external_content_source(u64 tid);
 };


### PR DESCRIPTION
Currently WIP, as I've not yet finished writing anything to test this. Posting here for review.

One thing that I'm noticing is that the content management code is becoming very convoluted. Perhaps there should be a different design where there is a stack of content providers that are queried for a given TID+NSO index, where each content provider can either supply the file, reject the file, or pass the request along to the next content provider.

- ExternalContentSource provider overrides everything
- HBL content provider
- SD content provider
- ExeFS content provider

This type of design would also allow a more powerful extension so that rather than using `SetExternalContentSource` to override a specific title's contents, a sysmodule could use a more powerful `AddExternalContentProvider` and use its own logic (rather than the limited logic available in loader) to determine override behavior. I'd like to hear your thoughts on this @SciresM.