### PR TITLE
Update Documentation for 0.7.2

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,72 @@
+# Changelog
+## 0.7.2
++ Fixed a bug in fs.mitm's LayeredFS read implementation that caused some games to crash when trying to read files.
++ Fixed a bug affecting 1.0.0 that caused games to crash with fatal error 2001-0106 on boot.
++ Improved filenames output by the make dist target.
++ General system stability improvements to enhance the user's experience.
+## 0.7.1
++ Fixed a bug preventing consoles on 4.0.0-4.1.0 from going to sleep and waking back up.
++ Fixed a bug preventing consoles on < 4.0.0 from booting without specific KIPs on the SD card.
++ An API was added to Atmosphère's Service Manager for deferring acquisition of all handles for specific services until after early initialization is completed.
++ General system stability improvements to enhance the user's experience.
+## 0.7.0
++ First official release of Atmosphère.
++ Supports the following featureset:
+  + Fusée, a custom bootloader.
+    + Supports loading/customizing of arbitrary KIPs from the SD card.
+    + Supports loading a custom kernel from the SD card ("/atmosphere/kernel.bin").
+    + Supports compile-time defined kernel patches on a per-firmware basis.
+    + All patches at paths like /atmosphere/kip_patches/<user-defined patch name>/<SHA256 of KIP>.ips will be applied to the relevant KIPs, allowing for easy distribution of patches supporting multiple versions.
+      + Both the IPS and IPS32 formats are supported.
+    + All patches at paths like /atmosphere/kernel_patches/<user-defined patch name>/<SHA256 of Kernel>.ips will be applied to the kernel, allowing for easy distribution of patches supporting multiple versions.
+      + Both the IPS and IPS32 formats are supported.
+    + Configurable by editing BCT.ini on the SD card.
+    + Atmosphère should also be launchable by the alternative hekate bootloader, for those who prefer it.
+  + Exosphère, a fully-featured custom secure monitor.
+    + Exosphere is a re-implementation of Nintendo's TrustZone firmware, fully replicating all of its features.
+    + In addition, it has been extended to provide information on current Atmosphere API version, for homebrew wishing to make use of it.
+  + Stratosphère, a set of custom system modules. This includes:
+    + A loader system module.
+      + Reimplementation of Nintendo's loader, fully replicating all original functionality.
+      + Configurable by editing /atmosphere/loader.ini
+      + First class support for the Homebrew Loader.
+        + An exefs NSP (default "/atmosphere/hbl.nsp") will be used in place of the victim title's exefs.
+        + By default, HBL will replace the album applet, but any application should also be supported.
+      + Extended to support arbitrary redirection of executable content to the SD card.
+        + Files will be preferentially loaded from /atmosphere/titles/<titleid>/exefs/, if present.
+        + Files present in the original exefs a user wants to mark as not present may be "stubbed" by creating a .stub file on the SD.
+        + If present, a PFS0 at /atmosphere/titles/<titleid>/exefs.nsp will fully replace the original exefs.
+        + Redirection is optionally toggleable by holding down certain buttons (by default, holding R disables redirection).
+      + Full support for patching NSO content is implemented.
+        + All patches at paths like /atmosphere/exefs_patches/<user-defined patch name>/<Hex Build-ID for NSO to patch>.ips will be applied, allowing for easy distribution of patches supporting multiple firmware versions and/or titles.
+        + Both the IPS and IPS32 formats are supported.
+      + Extended to support launching content from loose executable files on the SD card, without requiring any official installation.
+        + This is done by specifying FsStorageId_None on launch.
+    + A service manager system module.
+      + Reimplementation of Nintendo's service manager, fully replicating all original functionality.
+      + Compile-time support for reintroduction of "smhax", allowing clients to optionally skip service access verification by skipping initialization.
+      + Extended to allow homebrew to acquire more handles to privileged services than Nintendo natively allows.
+      + Extended to add a new API for installing Man-In-The-Middle listeners for arbitrary services.
+        + API can additionally be used to safely detect whether a service has been registered in a non-blocking way with no side-effects.
+        + Full API documentation to come.
+    + A process manager system module.
+      + Reimplementation of Nintendo's process manager, fully replicating all original functionality.
+      + Extended to allow homebrew to acquire handles to arbitrary processes, and thus read/modify system memory without blocking execution.
+      + Extended to allow homebrew to retrieve information about system resource limits.
+      + Extended by embedding a full, extended implementation of Nintendo's boot2 system module.
+        + Title launch order has been optimized in order to grant access to the SD card faster.
+        + The error-collection system module is intentionally not launched, preventing many system telemetry error reports from being generated at all.
+        + Users may place their own custom sysmodules on the SD card and flag them for automatic boot2 launch by creating a /atmosphere/titles/<title ID>/boot2.flag file on their SD card.
+    + A custom fs.mitm system module.
+      + Uses Atmosphère's MitM API in order to provide an easy means for users to modify game content.
+      + Intercepts all FS commands sent by games, with special handling for commands used to mount RomFS/DLC content to enable easy creation and distribution of game/DLC mods.
+        + fs.mitm will parse the base RomFS image for a game, a RomFS image located at /atmosphere/titles/<title ID>/romfs.bin, and all loose files in /atmosphere/titles/<title ID>/romfs/, and merge them together into a single RomFS image.
+        + When merging, loose files are preferred to content in the SD card romfs.bin image, and files from the SD card image are preferred to those in the base image.
+      + Can additionally be used to intercept commands sent by arbitrary system titles (excepting those launched before SD card is active), by creating a /atmosphere/titles/<title ID>/fsmitm.flag file on the SD card.
+      + Can be forcibly disabled for any title, by creating a /atmosphere/titles/<title ID>/fsmitm_disable.flag file on the SD card.
+      + Redirection is optionally toggleable by holding down certain buttons (by default, holding R disables redirection).
+    + A custom crash report system module.
+      + Serves as a drop-in replacement for Nintendo's own creport system module.
+      + Generates detailed, human-readable reports on system crashes, saving to /atmosphere/crash_reports/<timestamp>_<title ID>.log.
+      + Because reports are not sent to the erpt sysmodule, this disables all crash report related telemetry.
+  + General system stability improvements to enhance the user's experience.

--- a/docs/main.md
+++ b/docs/main.md
@@ -22,5 +22,8 @@ Stratosphère's modules include:
 ### Building Atmosphère
 A guide to building Atmosphère can be found [here](../docs/building.md).
 
-### Release Roadmap
-A roadmap of the releases of Atmosphère can be found [here](../docs/roadmap.md).
+### Upcoming Features
+A list of planned features for Atmosphère can be found [here](../docs/roadmap.md).
+
+### Release History
+A changelog of previous versions of Atmosphère can be found [here](../docs/changelog.md).

--- a/docs/modules/loader.md
+++ b/docs/modules/loader.md
@@ -53,11 +53,15 @@ When authoring patches, [hactool](https://github.com/SciresM/hactool) can be use
 
 ### HBL Support
 
-TODO
+Atmosphère can use the loader module in order to turn any game on your Switch's home menu into a launchpoint for the Homebrew Menu, rather than launching it through the album applet. This allows one to launch the Homebrew Menu with access to the ~3.2GB of RAM that the Switch reserves for games and applications, as opposed to the 442MB of RAM we are limited to when launching the Homebrew Menu from the album. This also means that it is no longer necessary to install homebrew as `.nsp` files on your Switch so long as you are using this method, as the only reason to do so is to allow the homebrew to access all of the Switch's available memory.
+
+In order to setup this method you will need the latest release of [hbmenu](https://github.com/switchbrew/nx-hbmenu/releases), and the latest release of [hbloader](https://github.com/switchbrew/nx-hbloader/releases). Place `hbmenu.nro` on the root of your Switch's SD Card, and place `hbl.nsp` in the atmosphere folder. From there, simply configure `loader.ini` in the atmosphere folder by replacing the Title ID in the ini (hbl_tid) (it is the Title ID for the album by default) with the Title ID of whatever game you wish to use to launch the Homebrew Menu. A list of Title IDs for Switch Games can be found [here](https://switchbrew.org/wiki/Title_list/Games). Afterwards you may reinsert your SD Card into your Switch and boot into Atmosphère as you normally would. You should now be able to boot into the Homebrew Menu by launching your designated game of choice.
 
 ### Button Overrides
 
-TODO
+By default `loader.ini` is configured to launch the Homebrew Menu when launching the game normally, and launching the game when selecting the game while holding down R. If you wish to change this, you can modify the override_key section of `loader.ini`. Placing an exclamation point in front of whatever button you wish to use will make it so that you will only launch the actual game while holding down that button, otherwise you will go into the Homebrew Menu. Removing the exclamation point will reverse this, meaning that you will boot into the Homebrew Menu only while holding down the assigned button when launching the game.
+
+For example, `override_key=!R` will run the game only while holding down R when launching it, otherwise it will boot into the Homebrew Menu. `override_key=R` will only boot into the Homebrew Menu while holding down R when launching the game, otherwise it will launch the game as normal.
 
 ### SM MITM Integration
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,19 +1,16 @@
-# Release Roadmap
-## Upcoming Releases
-### 0.7
-0.7 will be Atmosphère's first official release.
-This release will include:
-+ Fusée
-  + Supports loading/customizing of arbitrary KIPs from the SD card.
-  + Supports compile-time defined kernel patches on a per-firmware basis.
-  + Configurable by editing BCT.ini on the SD card.
-  + Atmosphère should also be launchable by the alternative hekate bootloader, for those who prefer it.
-+ Exosphère
-  + Exosphere is a re-implementation of Nintendo's TrustZone firmware, fully replicating all of its features.
-  + In addition, it has been extended to provide information on current Atmosphere API version, for homebrew wishing to make use of it.
-+ Stratosphère
-  + loader system module
-  + Service Manager system module (sm)
-  + Process Manager system module (pm)
-  + fs.mitm system module
-  + creport system module
+# Planned Features
+The following features are planned to be added in future versions of Atmosphère:
++ Thermosphère, a hypervisor-based emunand implementation.
++ A feature-rich debugging toolset (a component of Stratosphère).
+  + A custom debug monitor system module, providing an API for debugging Switch's processes. This may not be a reimplementation of Nintendo's own debug monitor.
+    + This should include a gdbstub implementation, possibly borrowing from Luma3DS's.
+    + This API should be additionally usable for RAM Editing/"Cheat Engine" purposes.
+  + A custom shell system module, providing an means for users to perform various RPC (with support for common/interesting functionality) on their Switch remotely. This may not be a reimplementation of Nintendo's own shell.
+    + This should support client connections over both Wi-Fi and USB.
+  + A custom logging system module, providing a means for other Atmosphère components (and possibly Nintendo's own system modules) to log debug output.
+    + This should support logging to the SD card, over Wi-Fi, and over USB.
++ An application-level plugin system.
+  + This will, ideally, work somewhat like NTR-CFW's plugin system on the 3DS, allowing users to run their own code in a game's process in their own thread.
++ An AR Code/Gameshark analog implementation, allowing for easy sharing/development of cheat codes to run on device.
++ Further extensions to existing Atmosphère components.
++ General system stability improvements to enhance the user's experience.


### PR DESCRIPTION
I have updated various sections of the documentation to reflect Atmosphère 0.7.2.

A couple of key changes I would like to mention:
The release roadmap is now a list of upcoming features. I have done this because as far as I am aware, we do not yet know in what version certain features will be added. When a feature on this list is added, I will remove it from the list.

I have added a changelog to the documentation. This log contains release notes for all versions of Atmosphère.

Finally, I have updated the HBL section of loader.md to explain how we are able to use any game on the Home Menu to launch hbmenu, as opposed to launching it from the album.