### PR TITLE
Add a way for users to identify where builds come from.

### DIFF
--- a/exosphere/Makefile
+++ b/exosphere/Makefile
@@ -34,6 +34,11 @@ INCLUDES	:=	include ../common/include
 #---------------------------------------------------------------------------------
 ARCH	:=	-march=armv8-a -mtune=cortex-a57 -mgeneral-regs-only #<- important
 DEFINES	:=	-D__CCPLEX__ -DATMOSPHERE_GIT_BRANCH=\"$(AMSBRANCH)\" -DATMOSPHERE_GIT_REV=\"$(AMSREV)\"
+
+ifneq ($(strip $(AMSSRC)),)
+	DEFINES	+= -DATMOSPHERE_BUILD_SOURCE=\"$(strip $(AMSSRC))\"
+endif
+
 CFLAGS	:= \
 	-g \
 	-O2 \

--- a/fusee/fusee-primary/Makefile
+++ b/fusee/fusee-primary/Makefile
@@ -35,6 +35,10 @@ INCLUDES	:=	include  ../../common/include
 ARCH	:=	-march=armv4t -mtune=arm7tdmi -mthumb -mthumb-interwork
 DEFINES :=	-D__BPMP__ -DFUSEE_STAGE1_SRC -DATMOSPHERE_GIT_BRANCH=\"$(AMSBRANCH)\" -DATMOSPHERE_GIT_REV=\"$(AMSREV)\"
 
+ifneq ($(strip $(AMSSRC)),)
+	DEFINES	+= -DATMOSPHERE_BUILD_SOURCE=\"$(strip $(AMSSRC))\"
+endif
+
 CFLAGS	:= \
 	-g \
 	-O2 \

--- a/fusee/fusee-secondary/Makefile
+++ b/fusee/fusee-secondary/Makefile
@@ -38,6 +38,10 @@ INCLUDES	:=	include ../../common/include
 ARCH	:=	-march=armv4t -mtune=arm7tdmi -marm
 DEFINES :=	-D__BPMP__ -DFUSEE_STAGE2_SRC -DATMOSPHERE_GIT_BRANCH=\"$(AMSBRANCH)\" -DATMOSPHERE_GIT_REV=\"$(AMSREV)\"
 
+ifneq ($(strip $(AMSSRC)),)
+	DEFINES	+= -DATMOSPHERE_BUILD_SOURCE=\"$(strip $(AMSSRC))\"
+endif
+
 CFLAGS	:= \
 	-g \
 	-O2 \

--- a/stratosphere/boot/Makefile
+++ b/stratosphere/boot/Makefile
@@ -34,6 +34,10 @@ EXEFS_SRC	:=	exefs_src
 
 DEFINES	:=	-DDISABLE_IPC -DATMOSPHERE_GIT_BRANCH=\"$(AMSBRANCH)\" -DATMOSPHERE_GIT_REV=\"$(AMSREV)\"
 
+ifneq ($(strip $(AMSSRC)),)
+	DEFINES	+= -DATMOSPHERE_BUILD_SOURCE=\"$(strip $(AMSSRC))\"
+endif
+
 #---------------------------------------------------------------------------------
 # options for code generation
 #---------------------------------------------------------------------------------

--- a/stratosphere/creport/Makefile
+++ b/stratosphere/creport/Makefile
@@ -33,6 +33,10 @@ EXEFS_SRC	:=	exefs_src
 
 DEFINES	:=	-DDISABLE_IPC -DATMOSPHERE_GIT_BRANCH=\"$(AMSBRANCH)\" -DATMOSPHERE_GIT_REV=\"$(AMSREV)\"
 
+ifneq ($(strip $(AMSSRC)),)
+	DEFINES	+= -DATMOSPHERE_BUILD_SOURCE=\"$(strip $(AMSSRC))\"
+endif
+
 #---------------------------------------------------------------------------------
 # options for code generation
 #---------------------------------------------------------------------------------

--- a/stratosphere/creport/source/creport_crash_report.cpp
+++ b/stratosphere/creport/source/creport_crash_report.cpp
@@ -292,7 +292,12 @@ void CrashReport::SaveReport() {
 
 void CrashReport::SaveToFile(FILE *f_report) {
     char buf[0x10] = {0};
-    fprintf(f_report, "Atmosphère Crash Report (v1.2):\n");
+
+    #ifdef ATMOSPHERE_BUILD_SOURCE
+        fprintf(f_report, "Atmosphère Crash Report (v1.2 [%s]):\n", ATMOSPHERE_BUILD_SOURCE);
+    #else
+        fprintf(f_report, "Atmosphère Crash Report (v1.2):\n");
+    #endif
     fprintf(f_report, "Result:                          0x%X (2%03d-%04d)\n\n", this->result, R_MODULE(this->result), R_DESCRIPTION(this->result));
     
     /* Process Info. */

--- a/stratosphere/fatal/Makefile
+++ b/stratosphere/fatal/Makefile
@@ -33,6 +33,10 @@ EXEFS_SRC	:=	exefs_src
 
 DEFINES	:=	-DDISABLE_IPC -DATMOSPHERE_GIT_BRANCH=\"$(AMSBRANCH)\" -DATMOSPHERE_GIT_REV=\"$(AMSREV)\"
 
+ifneq ($(strip $(AMSSRC)),)
+	DEFINES	+= -DATMOSPHERE_BUILD_SOURCE=\"$(strip $(AMSSRC))\"
+endif
+
 #---------------------------------------------------------------------------------
 # options for code generation
 #---------------------------------------------------------------------------------

--- a/stratosphere/fatal/source/fatal_task_screen.cpp
+++ b/stratosphere/fatal/source/fatal_task_screen.cpp
@@ -208,7 +208,11 @@ Result ShowFatalTask::ShowFatal() {
     FontManager::AddSpacingLines(0.5f);
     FontManager::PrintFormatLine("Title: %016lX", this->title_id);
     FontManager::AddSpacingLines(0.5f);
-    FontManager::PrintFormatLine(u8"Firmware: %s (Atmosphère %u.%u.%u-%s)", GetFatalConfig()->firmware_version.display_version, CURRENT_ATMOSPHERE_VERSION, GetAtmosphereGitRevision());
+    #ifdef ATMOSPHERE_BUILD_SOURCE
+        FontManager::PrintFormatLine(u8"Firmware: %s (Atmosphère %u.%u.%u-%s [%s])", GetFatalConfig()->firmware_version.display_version, CURRENT_ATMOSPHERE_VERSION, GetAtmosphereGitRevision(), ATMOSPHERE_BUILD_SOURCE);
+    #else
+        FontManager::PrintFormatLine(u8"Firmware: %s (Atmosphère %u.%u.%u-%s)", GetFatalConfig()->firmware_version.display_version, CURRENT_ATMOSPHERE_VERSION, GetAtmosphereGitRevision());
+    #endif
     FontManager::AddSpacingLines(1.5f);
     if (this->ctx->error_code != 0xCAFEF) {
         FontManager::Print(config->error_desc);

--- a/stratosphere/fs_mitm/Makefile
+++ b/stratosphere/fs_mitm/Makefile
@@ -33,6 +33,10 @@ EXEFS_SRC	:=	exefs_src
 
 DEFINES	:=	-DDISABLE_IPC -DATMOSPHERE_GIT_BRANCH=\"$(AMSBRANCH)\" -DATMOSPHERE_GIT_REV=\"$(AMSREV)\"
 
+ifneq ($(strip $(AMSSRC)),)
+	DEFINES	+= -DATMOSPHERE_BUILD_SOURCE=\"$(strip $(AMSSRC))\"
+endif
+
 #---------------------------------------------------------------------------------
 # options for code generation
 #---------------------------------------------------------------------------------

--- a/stratosphere/loader/Makefile
+++ b/stratosphere/loader/Makefile
@@ -33,6 +33,10 @@ EXEFS_SRC	:=	exefs_src
 
 DEFINES	:=	-DDISABLE_IPC -DATMOSPHERE_GIT_BRANCH=\"$(AMSBRANCH)\" -DATMOSPHERE_GIT_REV=\"$(AMSREV)\"
 
+ifneq ($(strip $(AMSSRC)),)
+	DEFINES	+= -DATMOSPHERE_BUILD_SOURCE=\"$(strip $(AMSSRC))\"
+endif
+
 #---------------------------------------------------------------------------------
 # options for code generation
 #---------------------------------------------------------------------------------

--- a/stratosphere/pm/Makefile
+++ b/stratosphere/pm/Makefile
@@ -33,6 +33,10 @@ EXEFS_SRC	:=	exefs_src
 
 DEFINES	:=	-DDISABLE_IPC -DATMOSPHERE_GIT_BRANCH=\"$(AMSBRANCH)\" -DATMOSPHERE_GIT_REV=\"$(AMSREV)\"
 
+ifneq ($(strip $(AMSSRC)),)
+	DEFINES	+= -DATMOSPHERE_BUILD_SOURCE=\"$(strip $(AMSSRC))\"
+endif
+
 #---------------------------------------------------------------------------------
 # options for code generation
 #---------------------------------------------------------------------------------

--- a/stratosphere/set_mitm/Makefile
+++ b/stratosphere/set_mitm/Makefile
@@ -33,6 +33,10 @@ EXEFS_SRC	:=	exefs_src
 
 DEFINES	:=	-DDISABLE_IPC -DATMOSPHERE_GIT_BRANCH=\"$(AMSBRANCH)\" -DATMOSPHERE_GIT_REV=\"$(AMSREV)\"
 
+ifneq ($(strip $(AMSSRC)),)
+	DEFINES	+= -DATMOSPHERE_BUILD_SOURCE=\"$(strip $(AMSSRC))\"
+endif
+
 #---------------------------------------------------------------------------------
 # options for code generation
 #---------------------------------------------------------------------------------

--- a/stratosphere/set_mitm/source/setsys_mitm_service.cpp
+++ b/stratosphere/set_mitm/source/setsys_mitm_service.cpp
@@ -36,7 +36,12 @@ static Result _GetFirmwareVersion(SetSysFirmwareVersion *out) {
             char display_version[sizeof(g_fw_version.display_version)] = {0};
             
             GetAtmosphereApiVersion(&major, &minor, &micro, nullptr, nullptr);
-            snprintf(display_version, sizeof(display_version), "%s (AMS %u.%u.%u)", g_fw_version.display_version, major, minor, micro);
+
+            #ifdef ATMOSPHERE_BUILD_SOURCE
+                snprintf(display_version, sizeof(display_version), "%s (AMS %u.%u.%u [%s])", g_fw_version.display_version, major, minor, micro, ATMOSPHERE_BUILD_SOURCE);
+            #else
+                snprintf(display_version, sizeof(display_version), "%s (AMS %u.%u.%u)", g_fw_version.display_version, major, minor, micro);
+            #endif
             
             memcpy(g_fw_version.display_version, display_version, sizeof(g_fw_version.display_version));
         }

--- a/stratosphere/sm/Makefile
+++ b/stratosphere/sm/Makefile
@@ -33,6 +33,10 @@ EXEFS_SRC	:=	exefs_src
 
 DEFINES	:=	-DDISABLE_IPC -DATMOSPHERE_GIT_BRANCH=\"$(AMSBRANCH)\" -DATMOSPHERE_GIT_REV=\"$(AMSREV)\"
 
+ifneq ($(strip $(AMSSRC)),)
+	DEFINES	+= -DATMOSPHERE_BUILD_SOURCE=\"$(strip $(AMSSRC))\"
+endif
+
 #---------------------------------------------------------------------------------
 # options for code generation
 #---------------------------------------------------------------------------------

--- a/thermosphere/Makefile
+++ b/thermosphere/Makefile
@@ -35,6 +35,10 @@ INCLUDES	:=	include ../common/include
 ARCH	:=	-march=armv8-a -mtune=cortex-a57
 DEFINES :=  -DATMOSPHERE_GIT_BRANCH=\"$(AMSBRANCH)\" -DATMOSPHERE_GIT_REV=\"$(AMSREV)\"
 
+ifneq ($(strip $(AMSSRC)),)
+	DEFINES	+= -DATMOSPHERE_BUILD_SOURCE=\"$(strip $(AMSSRC))\"
+endif
+
 CFLAGS	:= \
 		-g \
 		-O2 \


### PR DESCRIPTION
Very small tweak to allow for you to set an environment variable (AMSSRC) when building to add an identifier of the source of the build. It will just add it in brackets next to version numbers in the creport files, fatal screen, and system version identifier. The idea is to help with supporting users to know where their build came from. (I haven't actually tried building this, but the code changes are so simple I'm confident in it working.)