### PR TITLE
sm: add query registrations extension

### DIFF
--- a/stratosphere/sm/source/sm_manager_service.cpp
+++ b/stratosphere/sm/source/sm_manager_service.cpp
@@ -35,3 +35,10 @@ void ManagerService::AtmosphereHasMitm(Out<bool> out, SmServiceName service) {
     out.SetValue(Registration::HasMitm(smEncodeName(service.name)));
 }
 
+Result ManagerService::AtmosphereQueryRegistrations(u64 offset, OutBuffer<ServiceRecord> records, Out<u64> out_count, Out<u64> record_size) {
+    uint64_t count = records.num_elements;
+    Registration::QueryRegistrations(offset, records.buffer, &count);
+    out_count.SetValue(count);
+    record_size.SetValue(sizeof(ServiceRecord));
+    return 0;
+}

--- a/stratosphere/sm/source/sm_manager_service.hpp
+++ b/stratosphere/sm/source/sm_manager_service.hpp
@@ -26,6 +26,7 @@ enum ManagerServiceCmd {
     
     Manager_Cmd_AtmosphereEndInitDefers = 65000,
     Manager_Cmd_AtmosphereHasMitm = 65001,
+    Manager_Cmd_AtmosphereQueryRegistrations = 65002,
 };
 
 class ManagerService final : public IServiceObject {
@@ -35,6 +36,7 @@ class ManagerService final : public IServiceObject {
         virtual Result UnregisterProcess(u64 pid);
         virtual void AtmosphereEndInitDefers();
         virtual void AtmosphereHasMitm(Out<bool> out, SmServiceName service);
+        virtual Result AtmosphereQueryRegistrations(u64 offset, OutBuffer<ServiceRecord> records, Out<u64> out_count, Out<u64> record_size);
     public:
         DEFINE_SERVICE_DISPATCH_TABLE {
             MakeServiceCommandMeta<Manager_Cmd_RegisterProcess, &ManagerService::RegisterProcess>(),
@@ -42,5 +44,6 @@ class ManagerService final : public IServiceObject {
             
             MakeServiceCommandMeta<Manager_Cmd_AtmosphereEndInitDefers, &ManagerService::AtmosphereEndInitDefers>(),
             MakeServiceCommandMeta<Manager_Cmd_AtmosphereHasMitm, &ManagerService::AtmosphereHasMitm>(),
+            MakeServiceCommandMeta<Manager_Cmd_AtmosphereQueryRegistrations, &ManagerService::AtmosphereQueryRegistrations>(),
         };
 };

--- a/stratosphere/sm/source/sm_registration.cpp
+++ b/stratosphere/sm/source/sm_registration.cpp
@@ -567,7 +567,7 @@ void Registration::QueryRegistrations(u64 offset, ServiceRecord *out, u64 *count
     u64 space = *count;
     *count = 0;
 
-    for(auto i = g_service_list.begin() + offset; i < g_service_list.end() && space > 0; i++) {
+    for(auto i = g_service_list.begin(); i < g_service_list.end() && space > 0; i++) {
         if(i->service_name != 0) {
             if(offset > 0) {
                 offset--;

--- a/stratosphere/sm/source/sm_registration.cpp
+++ b/stratosphere/sm/source/sm_registration.cpp
@@ -562,3 +562,29 @@ Result Registration::AssociatePidTidForMitm(u64 pid, u64 tid) {
     }
     return 0x0;
 }
+
+void Registration::QueryRegistrations(u64 offset, ServiceRecord *out, u64 *count) {
+    u64 space = *count;
+    *count = 0;
+
+    for(auto i = g_service_list.begin() + offset; i < g_service_list.end() && space > 0; i++) {
+        if(i->service_name != 0) {
+            if(offset > 0) {
+                offset--;
+            } else {
+                ServiceRecord *out_record = out++;
+                
+                out_record->service_name = i->service_name;
+                out_record->owner_pid = i->owner_pid;
+                out_record->max_sessions = i->max_sessions;
+                out_record->mitm_pid = i->mitm_pid;
+                out_record->mitm_waiting_ack_pid = i->mitm_waiting_ack_pid;
+                out_record->is_light = i->is_light;
+                out_record->mitm_waiting_ack = i->mitm_waiting_ack;
+                    
+                space--;
+                (*count)++;
+            }
+        }
+    }
+}

--- a/stratosphere/sm/source/sm_registration.hpp
+++ b/stratosphere/sm/source/sm_registration.hpp
@@ -17,6 +17,8 @@
 #pragma once
 #include <switch.h>
 
+#include "sm_types.hpp"
+
 #define REGISTRATION_LIST_MAX_PROCESS (0x40)
 #define REGISTRATION_LIST_MAX_SERVICE (0x100)
 #define REGISTRATION_MAX_SAC_SIZE (0x200)
@@ -81,4 +83,5 @@ class Registration {
         static Result UninstallMitmForPid(u64 pid, u64 service);
         static Result AcknowledgeMitmSessionForPid(u64 pid, u64 service, Handle *out, u64 *out_pid);
         static Result AssociatePidTidForMitm(u64 pid, u64 tid);
+        static void QueryRegistrations(u64 offset, ServiceRecord *out, u64 *count);
 };

--- a/stratosphere/sm/source/sm_types.hpp
+++ b/stratosphere/sm/source/sm_types.hpp
@@ -20,3 +20,14 @@ struct SmServiceName {
 };
 
 static_assert(__alignof__(SmServiceName) == 1, "SmServiceName definition!");
+
+// for QueryRegistrations extension
+struct ServiceRecord {
+    u64 service_name;
+    u64 owner_pid;
+    u64 max_sessions;
+    u64 mitm_pid;
+    u64 mitm_waiting_ack_pid;
+    bool is_light;
+    bool mitm_waiting_ack;
+};


### PR DESCRIPTION
Adds an extension that can be used to query service registrations. The offset-count pattern is used by Nintendo code (ns:am ListApplicationRecord for example). I've made a new struct called `ServiceRecord` instead of using `Registration::Service` so that we can have a stable API if we need to change `Registration::Service`, but I've also added an output for the size of each record so that old client code can keep working if we want to add more fields to `ServiceRecord`.

Here's the code I tested this with: https://gist.github.com/misson20000/2e22a7a35ce67b87c6bc723a52df2d36. Note that my code is dangerous and doesn't care if `record_size` is smaller than it expects. The example pseudocode in the documentation is better about this.