### PR TITLE
stratosphere/Makefile: change KIPS to MODULES

### DIFF
--- a/stratosphere/Makefile
+++ b/stratosphere/Makefile
@@ -1,8 +1,6 @@
-KIPS := loader pm sm boot fs_mitm set_mitm creport fatal
+MODULES := loader pm sm boot fs_mitm set_mitm creport fatal
 
-#TODO: boot2 ?
-
-SUBFOLDERS := libstratosphere $(KIPS)
+SUBFOLDERS := libstratosphere $(MODULES)
 
 TOPTARGETS := all clean
 
@@ -11,6 +9,6 @@ $(TOPTARGETS): $(SUBFOLDERS)
 $(SUBFOLDERS):
 	$(MAKE) -C $@ $(MAKECMDGOALS)
 
-$(KIPS): libstratosphere
+$(MODULES): libstratosphere
 
 .PHONY: $(TOPTARGETS) $(SUBFOLDERS)


### PR DESCRIPTION
It's a bit confusing that this variable is called `KIPS`, when really only some of them are KIPs.