### PR TITLE
devkitARM r50-2 buildfix.

### DIFF
--- a/fusee/fusee-secondary/src/stratosphere.c
+++ b/fusee/fusee-secondary/src/stratosphere.c
@@ -18,6 +18,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <dirent.h>
+#include <sys/stat.h>
 #include "exocfg.h"
 #include "utils.h"
 #include "package2.h"


### PR DESCRIPTION
Fixes compilation errors relating to the function `stat` and the struct stat.

/mnt/c/develop/Atmosphere/fusee/fusee-secondary/src/stratosphere.c:207:17: error: implicit declaration of function 'stat'; did you mean 'strcat'? [-Werror=implicit-function-declaration]

mnt/c/develop/Atmosphere/fusee/fusee-secondary/src/stratosphere.c:206:25: error: storage size of 'kip_stat' isn't known
             struct stat kip_stat;