### PR TITLE
devkitARM r50-3 buildfix

### DIFF
--- a/fusee/fusee-secondary/src/lib/fatfs/ff.h
+++ b/fusee/fusee-secondary/src/lib/fatfs/ff.h
@@ -187,6 +187,7 @@ typedef struct {
 
 /* Directory object structure (DIR) */
 
+#ifndef _dirent_h_
 typedef struct {
 	FFOBJID	obj;			/* Object identifier */
 	DWORD	dptr;			/* Current read/write offset */
@@ -201,7 +202,7 @@ typedef struct {
 	const TCHAR* pat;		/* Pointer to the name matching pattern */
 #endif
 } DIR;
-
+#endif
 
 
 /* File information structure (FILINFO) */


### PR DESCRIPTION
After upgrading devkitARM to r50-3 i get this
In file included from /Users/julien/code/Atmosphere/fusee/fusee-secondary/src/fs_dev.c:28:
/Users/julien/code/Atmosphere/fusee/fusee-secondary/src/lib/fatfs/ff.h:204:3: error: conflicting types for 'DIR'
 } DIR;
   ^~~
In file included from /opt/devkitpro/devkitARM/arm-none-eabi/include/sys/iosupport.h:13,
                 from /Users/julien/code/Atmosphere/fusee/fusee-secondary/src/fs_dev.c:24:
/opt/devkitpro/devkitARM/arm-none-eabi/include/sys/dirent.h:43:4: note: previous declaration of 'DIR' was here
  } DIR;
    ^~~

fixed with editing ff.h on DIR type declaration and test if _dirent_h_ was already included so DIR is defined