### PR TITLE
Allow the user to build with a prebuilt sept-secondary blob via a SEPT_ENC_PATH variable.

### DIFF
--- a/sept/sept-secondary/Makefile
+++ b/sept/sept-secondary/Makefile
@@ -120,8 +120,12 @@ check_rebootstub:
 	@$(MAKE) -C $(AMS)/exosphere/rebootstub all
 
 $(BUILD):
+ifeq ($(strip $(SEPT_ENC_PATH)),)
 	@[ -d $@ ] || mkdir -p $@
 	@$(MAKE) --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile
+else
+	@cp $(SEPT_ENC_PATH) $(TOPDIR)/sept-secondary.enc
+endif
 
 #---------------------------------------------------------------------------------
 clean:


### PR DESCRIPTION
Since most of us cannot encrypt & sign our own payload, it makes sense to allow for the usage of the pre-built one provided by 0.8.4, and skip the build process of sept-secondary.

I don't speak makefile-ese very well, so if there's a better place to put it then please feel free to suggest it, I just went for the least intrusive spot I can find.