### PR TITLE
Fix sept-secondary build when using prebuild sept-secondary.enc

### DIFF
--- a/sept/sept-secondary/Makefile
+++ b/sept/sept-secondary/Makefile
@@ -124,6 +124,7 @@ ifeq ($(strip $(SEPT_ENC_PATH)),)
 	@[ -d $@ ] || mkdir -p $@
 	@$(MAKE) --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile
 else
+	@touch $(TOPDIR)/sept-secondary.bin
 	@cp $(SEPT_ENC_PATH) $(TOPDIR)/sept-secondary.enc
 endif
 


### PR DESCRIPTION
Hello,

This PR fixes the `make dist` after a fresh clone or clean when using the prebuild sept-secondary.enc ($SEPT_ENC_PATH)

Currently failing because sept-secondary.bin is not found