### PR TITLE
Makefile tweaks

### DIFF
--- a/fusee/fusee-secondary/Makefile
+++ b/fusee/fusee-secondary/Makefile
@@ -159,6 +159,7 @@ clean:
 	@$(MAKE) -C $(AMS)/exosphere clean
 	@$(MAKE) -C $(AMS)/thermosphere clean
 	@$(MAKE) -C $(AMS)/stratosphere clean
+	@$(MAKE) -C $(AMS)/sept clean
 	@rm -fr $(BUILD) $(TARGET).bin $(TARGET).elf
 
 #---------------------------------------------------------------------------------

--- a/sept/sept-secondary/Makefile
+++ b/sept/sept-secondary/Makefile
@@ -124,15 +124,15 @@ ifeq ($(strip $(SEPT_ENC_PATH)),)
 	@[ -d $@ ] || mkdir -p $@
 	@$(MAKE) --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile
 else
-	@touch $(TOPDIR)/sept-secondary.bin
-	@cp $(SEPT_ENC_PATH) $(TOPDIR)/sept-secondary.enc
+	@touch $(TOPDIR)/$(TARGET).bin
+	@cp $(SEPT_ENC_PATH) $(TOPDIR)/$(TARGET).enc
 endif
 
 #---------------------------------------------------------------------------------
 clean:
 	@echo clean ...
 	@$(MAKE) -C $(AMS)/exosphere/rebootstub clean
-	@rm -fr $(BUILD) $(TARGET).bin $(TARGET).elf
+	@rm -fr $(BUILD) $(TARGET).bin $(TARGET).enc $(TARGET).elf
 
 
 #---------------------------------------------------------------------------------


### PR DESCRIPTION
-Have fusee-secondary's makefile clean sept-secondary as required.
-Use $(TARGET) variable for sept-secondary, and clean the encrypted output as required.

Currently make clean doesn't clean sept (either stage), and when it does, it leaves the encrypted second stage binary output. I also changed the hard-coded names to be more flexible if the folder name should change in the future.