### PR TITLE
Add info to set_mitm docs, clean up loader docs

### DIFF
--- a/docs/modules/fs_mitm.md
+++ b/docs/modules/fs_mitm.md
@@ -1,2 +1,2 @@
 # fs_mitm
-fs_mitm is a sysmodule that enables intercepting file system operations. This module can log, deny, delay, replace, or redirect any request made to the filesystem. It enables LayeredFS to function, which allows for game mods.
+fs_mitm is a sysmodule that enables intercepting file system operations. This module can log, deny, delay, replace, or redirect any request made to the filesystem. It enables LayeredFS to function, which allows for replacment of game assets.

--- a/docs/modules/fs_mitm.md
+++ b/docs/modules/fs_mitm.md
@@ -1,2 +1,2 @@
 # fs_mitm
-fs_mitm is a sysmodule that enables intercepting file system operations. This module can log, deny, delay, replace, or redirect any request made to the filesystem. It enables LayeredFS to function, which allows for replacment of game assets.
+fs_mitm is a sysmodule that enables intercepting file system operations. This module can log, deny, delay, replace, or redirect any request made to the filesystem. It enables LayeredFS to function, which allows for replacement of game assets.

--- a/docs/modules/loader.md
+++ b/docs/modules/loader.md
@@ -55,13 +55,36 @@ When authoring patches, [hactool](https://github.com/SciresM/hactool) can be use
 
 Atmosphère can use the loader module in order to turn any game on your Switch's home menu into a launchpoint for the Homebrew Menu, rather than launching it through the album applet. This allows one to launch the Homebrew Menu with access to the ~3.2GB of RAM that the Switch reserves for games and applications, as opposed to the 442MB of RAM we are limited to when launching the Homebrew Menu from the album. This also means that it is no longer necessary to install homebrew as `.nsp` files on your Switch so long as you are using this method, as the only reason to do so is to allow the homebrew to access all of the Switch's available memory.
 
-In order to setup this method you will need the latest release of [hbmenu](https://github.com/switchbrew/nx-hbmenu/releases), and the latest release of [hbloader](https://github.com/switchbrew/nx-hbloader/releases). Place `hbmenu.nro` on the root of your Switch's SD Card, and place `hbl.nsp` in the atmosphere folder. From there, simply configure `loader.ini` in the atmosphere folder by replacing the Title ID in the ini (title_id in the [hbl_config] section) (it is the Title ID for the album by default) with the Title ID of whatever game you wish to use to launch the Homebrew Menu. A list of Title IDs for Switch Games can be found [here](https://switchbrew.org/wiki/Title_list/Games). Afterwards you may reinsert your SD Card into your Switch and boot into Atmosphère as you normally would. You should now be able to boot into the Homebrew Menu by launching your designated game of choice.
+In order to setup this method you will need the latest release of [hbmenu](https://github.com/switchbrew/nx-hbmenu/releases), and the latest release of [hbloader](https://github.com/switchbrew/nx-hbloader/releases). Place `hbmenu.nro` on the root of your Switch's SD Card, and place `hbl.nsp` in the atmosphere folder. From there, simply launch any title while holding the button specified in `loader.ini`.
 
 ### Button Overrides
 
-By default `loader.ini` is configured to launch the Homebrew Menu when launching the game normally, and launching the game when selecting the game while holding down R. If you wish to change this, you can modify the override_key section of `loader.ini`. Placing an exclamation point in front of whatever button you wish to use will make it so that you will only launch the actual game while holding down that button, otherwise you will go into the Homebrew Menu. Removing the exclamation point will reverse this, meaning that you will boot into the Homebrew Menu only while holding down the assigned button when launching the game.
+By default `loader.ini` is configured to launch the Homebrew Menu when launching any game while holding down the override key. If you wish to change this, you can modify the override_key section of `loader.ini`. Alternatively, if you would like to only allow hbmenu on a specific app, configure `loader.ini` in the atmosphere folder by replacing the Title ID in the ini (title_id in the [hbl_config] section, it is the Title ID for the album by default) with the Title ID of whatever game you wish to use to launch the Homebrew Menu, and set override_any_app to false. A list of Title IDs for Switch Games can be found [here](https://switchbrew.org/wiki/Title_list/Games).
 
-For example, `override_key=!R` will run the game only while holding down R when launching it, otherwise it will boot into the Homebrew Menu. `override_key=R` will only boot into the Homebrew Menu while holding down R when launching the game, otherwise it will launch the game as normal.
+To invert the behaviour of the override key, place an exclamation point in front of whatever button you wish to use. It will launch the actual game while holding down that button, instead of going into the Homebrew Menu. For example, `override_key=!R` will run the game only while holding down R when launching it, otherwise it will boot into the Homebrew Menu. Afterwards you may reinsert your SD Card into your Switch and boot into Atmosphère as you normally would. You should now be able to boot into the Homebrew Menu by launching your designated title of choice.
+
+A list of valid buttons can be found here:
+
+| Formal Name | .ini Name |
+| ----------- | --------- |
+| A Button    | A         |
+| B Button    | B         |
+| X Button    | X         |
+| Y Button    | Y         |
+| Left Stick  | LS        |
+| Right Stick | RS        |
+| L Button    | L         |
+| R Button    | R         |
+| ZL Button   | ZL        |
+| ZR Button   | ZR        |
+| + Button    | PLUS      |
+| - Button    | MINUS     |
+| Left Dpad   | DLEFT     |
+| Up Dpad     | DUP       |
+| Right Dpad  | DRIGHT    |
+| Down Dpad   | DDOWN     |
+| SL Button   | SL        |
+| SR Button   | SR        |
 
 ### SM MITM Integration
 

--- a/docs/modules/set_mitm.md
+++ b/docs/modules/set_mitm.md
@@ -50,5 +50,22 @@ upload_enabled = u8!0x0
 
 ### Atmosphère Custom Settings
 
-At present, Atmosphère implements no custom settings. However, this is subject to change in the future, and any\
-custom settings will be documented here as they are added.
+At the time of writing, Atmosphère implements two custom settings, found in the `atmosphere` section.\
+
+While not used for set_mitm, `power_menu_reboot_function` is loaded and controls the reboot behaviour of the console. By default, this value\
+is "payload", where the console will automatically reboot into the RCM payload stored in `sdmc:/atmosphere/reboot_payload.bin`.\
+(This payload is also used for fatal, upon a serious crash.) Setting the value to "rcm" reboots directly into RCM, and setting the value\
+to "normal" skips these behaviours.
+
+```
+[atmosphere]
+power_menu_reboot_function = str!payload
+```
+
+`dmnt_cheats_enabled_by_default` controls the behaviour of dmnt's cheat functionality. By default, this value is "0x1", enabling any cheats\
+defined by the user. Check [cheats](../cheats.md) for more information about Atmosphère's cheat functionality.
+
+```
+[atmosphere]
+dmnt_cheats_enabled_by_default = u8!0x1
+```


### PR DESCRIPTION
Also add the list of buttons found in all cases of ParseOverrideKey. Let me know what else needs to be updated (I'm aware much of it is outdated, but I'm not familiar enough with the inner workings of AMS to rewrite them all.)