### PR TITLE
fatal_font: Add missing va_end() calls to PrintFormatLine() and PrintFormat()

### DIFF
--- a/stratosphere/fatal/source/fatal_font.cpp
+++ b/stratosphere/fatal/source/fatal_font.cpp
@@ -126,12 +126,13 @@ void FontManager::PrintLine(const char *str) {
 }
 
 void FontManager::PrintFormatLine(const char *format, ...) {
+    char char_buf[0x400];
+
     va_list va_arg;
     va_start(va_arg, format);
-    
-    char char_buf[0x400];
     vsnprintf(char_buf, sizeof(char_buf), format, va_arg);
-    
+    va_end(va_arg);
+
     PrintLine(char_buf);
 }
 
@@ -140,12 +141,13 @@ void FontManager::Print(const char *str) {
 }
 
 void FontManager::PrintFormat(const char *format, ...) {
+    char char_buf[0x400];
+
     va_list va_arg;
     va_start(va_arg, format);
-    
-    char char_buf[0x400];
     vsnprintf(char_buf, sizeof(char_buf), format, va_arg);
-    
+    va_end(va_arg);
+
     Print(char_buf);
 }
 


### PR DESCRIPTION
Fairly self-explanatory. Ensures va_start() is balanced with va_end()