### PR TITLE
fs_mitm/fs_dir_utils: Amend logic error within IterateDirectoryRecursivelyInternal

### DIFF
--- a/stratosphere/ams_mitm/source/fs_mitm/fs_dir_utils.hpp
+++ b/stratosphere/ams_mitm/source/fs_mitm/fs_dir_utils.hpp
@@ -32,7 +32,7 @@ class FsDirUtils {
                 return rc;
             }
 
-            const size_t parent_len = strnlen(work_path.str, sizeof(work_path.str - 1));
+            const size_t parent_len = strnlen(work_path.str, sizeof(work_path.str) - 1);
 
             /* Read and handle entries. */
             while (true) {


### PR DESCRIPTION
This likely intended to get the size of the string and then subtract the null terminator byte. Instead, this would always result in a sizeof of 8.