### PR TITLE
loader: Silence Wmissing-field-initializers warnings

### DIFF
--- a/stratosphere/loader/source/ldr_content_management.cpp
+++ b/stratosphere/loader/source/ldr_content_management.cpp
@@ -29,8 +29,8 @@
 
 #include "ini.h"
 
-static FsFileSystem g_CodeFileSystem = {0};
-static FsFileSystem g_HblFileSystem = {0};
+static FsFileSystem g_CodeFileSystem = {};
+static FsFileSystem g_HblFileSystem = {};
 
 static std::vector<u64> g_created_titles;
 static bool g_has_initialized_fs_dev = false;

--- a/stratosphere/loader/source/ldr_debug_monitor.cpp
+++ b/stratosphere/loader/source/ldr_debug_monitor.cpp
@@ -33,7 +33,7 @@ void DebugMonitorService::ClearLaunchQueue() {
 
 Result DebugMonitorService::GetNsoInfo(Out<u32> count, OutPointerWithClientSize<Registration::NsoInfo> out, u64 pid) {
     /* Zero out the output memory. */
-    std::fill(out.pointer, out.pointer + out.num_elements, (const Registration::NsoInfo){0});
+    std::fill(out.pointer, out.pointer + out.num_elements, Registration::NsoInfo{});
     /* Actually return the nso infos. */
     return Registration::GetNsoInfosForProcessId(out.pointer, out.num_elements, pid, count.GetPointer());
 }

--- a/stratosphere/loader/source/ldr_launch_queue.cpp
+++ b/stratosphere/loader/source/ldr_launch_queue.cpp
@@ -22,7 +22,7 @@
 #include "ldr_launch_queue.hpp"
 #include "meta_tools.hpp"
 
-static std::array<LaunchQueue::LaunchItem, LAUNCH_QUEUE_SIZE> g_launch_queue = {0};
+static std::array<LaunchQueue::LaunchItem, LAUNCH_QUEUE_SIZE> g_launch_queue = {};
 
 Result LaunchQueue::Add(u64 tid, const char *args, u64 arg_size) {
     if (arg_size > LAUNCH_QUEUE_ARG_SIZE_MAX) {

--- a/stratosphere/loader/source/ldr_map.cpp
+++ b/stratosphere/loader/source/ldr_map.cpp
@@ -38,8 +38,8 @@ Result MapUtils::MapCodeMemoryForProcess(Handle process_h, bool is_64_bit_addres
 }
 
 Result MapUtils::LocateSpaceForMapModern(u64 *out, u64 out_size) {
-    MemoryInfo mem_info = {0};
-    AddressSpaceInfo address_space = {0};
+    MemoryInfo mem_info = {};
+    AddressSpaceInfo address_space = {};
     u32 page_info = 0;
     u64 cur_base = 0, cur_end = 0;
     Result rc;
@@ -94,7 +94,7 @@ Result MapUtils::LocateSpaceForMapModern(u64 *out, u64 out_size) {
 
 
 Result MapUtils::LocateSpaceForMapDeprecated(u64 *out, u64 out_size) {
-    MemoryInfo mem_info = {0};
+    MemoryInfo mem_info = {};
     u32 page_info = 0;
     Result rc;
     
@@ -128,7 +128,7 @@ Result MapUtils::LocateSpaceForMapDeprecated(u64 *out, u64 out_size) {
 }
 
 Result MapUtils::MapCodeMemoryForProcessModern(Handle process_h, u64 base_address, u64 size, u64 *out_code_memory_address) {
-    AddressSpaceInfo address_space = {0};
+    AddressSpaceInfo address_space = {};
     Result rc;
     
     if (R_FAILED((rc = GetAddressSpaceInfo(&address_space, process_h)))) {

--- a/stratosphere/loader/source/ldr_npdm.cpp
+++ b/stratosphere/loader/source/ldr_npdm.cpp
@@ -84,7 +84,7 @@ FILE *NpdmUtils::OpenNpdm(u64 title_id) {
 Result NpdmUtils::LoadNpdmInternal(FILE *f_npdm, NpdmUtils::NpdmCache *cache) {
     Result rc;
     
-    cache->info = (const NpdmUtils::NpdmInfo){0};
+    cache->info = {};
 
     rc = ResultFsPathNotFound;
     if (f_npdm == NULL) {
@@ -519,6 +519,6 @@ u32 NpdmUtils::GetApplicationTypeRaw(u32 *caps, size_t num_caps) {
 
 void NpdmUtils::InvalidateCache(u64 tid) {
     if (g_npdm_cache.info.title_id == tid) {
-        g_npdm_cache.info = (const NpdmUtils::NpdmInfo){0};
+        g_npdm_cache.info = {};
     }
 }

--- a/stratosphere/loader/source/ldr_nro.cpp
+++ b/stratosphere/loader/source/ldr_nro.cpp
@@ -46,9 +46,9 @@ Result NroUtils::ValidateNrrHeader(NrrHeader *header, u64 size, u64 title_id_min
 }
 
 Result NroUtils::LoadNro(Registration::Process *target_proc, Handle process_h, u64 nro_heap_address, u64 nro_heap_size, u64 bss_heap_address, u64 bss_heap_size, u64 *out_address) {
-    NroHeader nro_hdr = {0};
-    MappedCodeMemory mcm_nro = {0};
-    MappedCodeMemory mcm_bss = {0};
+    NroHeader nro_hdr = {};
+    MappedCodeMemory mcm_nro = {};
+    MappedCodeMemory mcm_bss = {};
     unsigned int i;
     Result rc = ResultSuccess;
     u8 nro_hash[0x20];

--- a/stratosphere/loader/source/ldr_nso.cpp
+++ b/stratosphere/loader/source/ldr_nso.cpp
@@ -107,7 +107,7 @@ Result NsoUtils::LoadNsoHeaders(u64 title_id) {
     
     /* Zero out the cache. */
     std::fill(g_nso_present, g_nso_present + NSO_NUM_MAX, false);
-    std::fill(g_nso_headers, g_nso_headers + NSO_NUM_MAX, (const NsoUtils::NsoHeader &){0});
+    std::fill(g_nso_headers, g_nso_headers + NSO_NUM_MAX, NsoUtils::NsoHeader{});
     
     for (unsigned int i = 0; i < NSO_NUM_MAX; i++) {
         f_nso = OpenNso(i, title_id);
@@ -161,7 +161,8 @@ Result NsoUtils::ValidateNsoLoadSet() {
 
 
 Result NsoUtils::CalculateNsoLoadExtents(u32 addspace_type, u32 args_size, NsoLoadExtents *extents) {
-    *extents = (const NsoUtils::NsoLoadExtents){0};
+    *extents = {};
+
     /* Calculate base offsets. */
     for (unsigned int i = 0; i < NSO_NUM_MAX; i++) {
         if (g_nso_present[i]) {

--- a/stratosphere/loader/source/ldr_process_creation.cpp
+++ b/stratosphere/loader/source/ldr_process_creation.cpp
@@ -27,7 +27,7 @@
 
 Result ProcessCreation::InitializeProcessInfo(NpdmUtils::NpdmInfo *npdm, Handle reslimit_h, u64 arg_flags, ProcessInfo *out_proc_info) {
     /* Initialize a ProcessInfo using an npdm. */
-    *out_proc_info = (const ProcessCreation::ProcessInfo){0};
+    *out_proc_info = {};
     
     /* Copy all but last char of name, insert NULL terminator. */
     std::copy(npdm->header->title_name, npdm->header->title_name + sizeof(out_proc_info->name) - 1, out_proc_info->name);
@@ -111,9 +111,9 @@ Result ProcessCreation::InitializeProcessInfo(NpdmUtils::NpdmInfo *npdm, Handle 
 }
 
 Result ProcessCreation::CreateProcess(Handle *out_process_h, u64 index, char *nca_path, LaunchQueue::LaunchItem *launch_item, u64 arg_flags, Handle reslimit_h) {
-    NpdmUtils::NpdmInfo npdm_info = {0};
-    ProcessInfo process_info = {0};
-    NsoUtils::NsoLoadExtents nso_extents = {0};
+    NpdmUtils::NpdmInfo npdm_info = {};
+    ProcessInfo process_info = {};
+    NsoUtils::NsoLoadExtents nso_extents = {};
     Registration::Process *target_process;
     Handle process_h = 0;
     u64 process_id = 0;

--- a/stratosphere/loader/source/ldr_process_manager.cpp
+++ b/stratosphere/loader/source/ldr_process_manager.cpp
@@ -63,7 +63,7 @@ Result ProcessManagerService::GetProgramInfo(OutPointerWithServerSize<ProcessMan
     Result rc;
     char nca_path[FS_MAX_PATH] = {0};
     /* Zero output. */
-    std::fill(out_program_info.pointer, out_program_info.pointer + out_program_info.num_elements, (const ProcessManagerService::ProgramInfo){0});
+    std::fill(out_program_info.pointer, out_program_info.pointer + out_program_info.num_elements, ProcessManagerService::ProgramInfo{});
     
     rc = PopulateProgramInfoBuffer(out_program_info.pointer, &tid_sid);
     

--- a/stratosphere/loader/source/ldr_registration.cpp
+++ b/stratosphere/loader/source/ldr_registration.cpp
@@ -22,7 +22,7 @@
 #include "ldr_registration.hpp"
 #include "ldr_nro.hpp"
 
-static Registration::List g_registration_list = {0};
+static Registration::List g_registration_list = {};
 static u64 g_num_registered = 1;
 
 Registration::Process *Registration::GetFreeProcess() {
@@ -67,7 +67,7 @@ bool Registration::RegisterTidSid(const TidSid *tid_sid, u64 *out_index) {
     }
     
     /* Reset the process. */
-    *free_process = {0};
+    *free_process = {};
     free_process->tid_sid = *tid_sid;
     free_process->in_use = true;
     free_process->index = g_num_registered++;
@@ -82,7 +82,7 @@ bool Registration::UnregisterIndex(u64 index) {
     }
     
     /* Reset the process. */
-    *target_process = {0};
+    *target_process = {};
     return true;
 }
 
@@ -251,7 +251,7 @@ Result Registration::RemoveNroInfo(u64 index, Handle process_h, u64 nro_heap_add
                     rc = svcUnmapProcessCodeMemory(process_h, info->base_address, nro_heap_address, info->text_size + info->ro_size);
                 }
             }
-            target_process->nro_infos[i] = (const NroInfo ){0};
+            target_process->nro_infos[i] = {};
             return rc;
         }
     }

--- a/stratosphere/loader/source/ldr_ro_service.cpp
+++ b/stratosphere/loader/source/ldr_ro_service.cpp
@@ -72,7 +72,7 @@ Result RelocatableObjectsService::UnloadNro(PidDescriptor pid_desc, u64 nro_addr
 Result RelocatableObjectsService::LoadNrr(PidDescriptor pid_desc, u64 nrr_address, u64 nrr_size) {
     Result rc = ResultSuccess;
     Registration::Process *target_proc = NULL;
-    MappedCodeMemory nrr_info = {0};
+    MappedCodeMemory nrr_info = {};
     ON_SCOPE_EXIT {
         if (R_FAILED(rc) && nrr_info.IsActive()) {
             nrr_info.Close();


### PR DESCRIPTION
Specifying 0 as the initial entry of a structure braced initializer is a C-ism. C++ permits using an empty set of braces to signify the same behavior. Since no aggregate members are specified, this also silences -Wmissing-field-initializers warnings.