### PR TITLE
ldr_map: Silence lingering initializer warning

### DIFF
--- a/stratosphere/loader/source/ldr_map.hpp
+++ b/stratosphere/loader/source/ldr_map.hpp
@@ -170,6 +170,6 @@ struct MappedCodeMemory {
                 /* TODO: panic(). */
             }
         }
-        *this = (const MappedCodeMemory){0};
+        *this = {};
     }
 };


### PR DESCRIPTION
One initializer warning case that I seem to have missed in the loader code (my bad).