### PR TITLE
Implement PRODINFO blanking and redirection

### DIFF
--- a/stratosphere/ams_mitm/source/fs_mitm/fsmitm_service.cpp
+++ b/stratosphere/ams_mitm/source/fs_mitm/fsmitm_service.cpp
@@ -269,12 +269,12 @@ Result FsMitmService::OpenBisStorage(Out<std::shared_ptr<IStorageInterface>> out
                 if (has_blank_cal0_flag) {
                     FsFile file;
 
-                    rc = Utils::OpenBlankProdinfoFile(&file);
+                    rc = Utils::OpenBlankProdInfoFile(&file);
                     if (R_FAILED(rc)) {
                         return rc;
                     }
                     
-                    storage = std::make_shared<IStorageInterface>(new FileStorage(new ProxyFile(&file))); /* Should we make this read-only? */
+                    storage = std::make_shared<IStorageInterface>(new FileStorage(new ProxyFile(&file)));
                 } else if (is_sysmodule || has_cal0_read_flag) {
                     /* PRODINFO should *never* be writable. */
                     storage = std::make_shared<IStorageInterface>(new ROProxyStorage(bis_storage));

--- a/stratosphere/ams_mitm/source/utils.cpp
+++ b/stratosphere/ams_mitm/source/utils.cpp
@@ -673,7 +673,7 @@ void Utils::RebootToFatalError(AtmosphereFatalErrorContext *ctx) {
 void Utils::CreateBlankProdInfoIfNeeded() {
     Result rc;
 
-    rc = fsFsOpenFile(&g_sd_filesystem, "/atmosphere/automatic_backups/prodinfo_blank.bin", FS_OPEN_READ, &g_blank_prodinfo_file);
+    rc = fsFsOpenFile(&g_sd_filesystem, "/atmosphere/automatic_backups/prodinfo_blank.bin", FS_OPEN_READ | FS_OPEN_WRITE, &g_blank_prodinfo_file);
     if (R_SUCCEEDED(rc)) {
         return;
     }
@@ -723,7 +723,7 @@ void Utils::CreateBlankProdInfoIfNeeded() {
         memcpy(&p[hash_offset], hash, 0x20);
     }
 
-    rc = fsFsOpenFile(&g_sd_filesystem, "/atmosphere/automatic_backups/prodinfo_blank.bin", FS_OPEN_WRITE, &g_blank_prodinfo_file);
+    rc = fsFsOpenFile(&g_sd_filesystem, "/atmosphere/automatic_backups/prodinfo_blank.bin", FS_OPEN_READ | FS_OPEN_WRITE, &g_blank_prodinfo_file);
     if (R_FAILED(rc)) {
         std::abort();
     }

--- a/stratosphere/ams_mitm/source/utils.cpp
+++ b/stratosphere/ams_mitm/source/utils.cpp
@@ -708,7 +708,7 @@ void Utils::CreateBlankProdinfoIfNeeded() {
 
         u8 data[data_size];
 
-        memcpy(&data, p ? g_cal0_backup[data_offset] : g_cal0_storage_backup[data_offset], data_size);
+        memcpy(&data, p ? &g_cal0_backup[data_offset] : &g_cal0_storage_backup[data_offset], data_size);
 
         u8 hash[0x20];
 

--- a/stratosphere/ams_mitm/source/utils.cpp
+++ b/stratosphere/ams_mitm/source/utils.cpp
@@ -754,14 +754,7 @@ void Utils::CreateBlankProdInfoIfNeeded() {
 }
 
 Result Utils::OpenBlankProdInfoFile(FsFile *out) {
-    FsFile file = g_blank_prodinfo_file;
-
-    Result rc = ipcCloneSession(g_blank_prodinfo_file.s.handle, 1, &file.s.handle);
-    if (R_SUCCEEDED(rc)) {
-        *out = file;
-    }
-
-    return rc;
+    return fsFsOpenFile(&g_sd_filesystem, "/atmosphere/automatic_backups/prodinfo_blank.bin", FS_OPEN_READ, out);
 }
 
 bool Utils::IsCal0Valid(u8* cal0) {

--- a/stratosphere/ams_mitm/source/utils.cpp
+++ b/stratosphere/ams_mitm/source/utils.cpp
@@ -754,7 +754,14 @@ void Utils::CreateBlankProdInfoIfNeeded() {
 }
 
 Result Utils::OpenBlankProdInfoFile(FsFile *out) {
-    return ipcCloneSession(g_blank_prodinfo_file.s.handle, 1, &out->s.handle);
+    FsFile file = g_blank_prodinfo_file;
+
+    Result rc = ipcCloneSession(g_blank_prodinfo_file.s.handle, 1, &file.s.handle);
+    if (R_SUCCEEDED(rc)) {
+        *out = file;
+    }
+
+    return rc;
 }
 
 bool Utils::IsCal0Valid(u8* cal0) {

--- a/stratosphere/ams_mitm/source/utils.cpp
+++ b/stratosphere/ams_mitm/source/utils.cpp
@@ -673,7 +673,7 @@ void Utils::RebootToFatalError(AtmosphereFatalErrorContext *ctx) {
 void Utils::CreateBlankProdInfoIfNeeded() {
     Result rc;
 
-    rc = fsFsOpenFile(&g_sd_filesystem, "/atmosphere/automatic_backups/prodinfo_blank.bin", FS_OPEN_READ | FS_OPEN_WRITE, &g_blank_prodinfo_file);
+    rc = fsFsOpenFile(&g_sd_filesystem, "/atmosphere/automatic_backups/prodinfo_blank.bin", FS_OPEN_READ, &g_blank_prodinfo_file);
     if (R_SUCCEEDED(rc)) {
         return;
     }
@@ -723,22 +723,31 @@ void Utils::CreateBlankProdInfoIfNeeded() {
         memcpy(&p[hash_offset], hash, 0x20);
     }
 
-    rc = fsFsOpenFile(&g_sd_filesystem, "/atmosphere/automatic_backups/prodinfo_blank.bin", FS_OPEN_READ | FS_OPEN_WRITE, &g_blank_prodinfo_file);
+    FsFile file;
+
+    rc = fsFsOpenFile(&g_sd_filesystem, "/atmosphere/automatic_backups/prodinfo_blank.bin", FS_OPEN_WRITE, &file);
     if (R_FAILED(rc)) {
         std::abort();
     }
 
-    rc = fsFileSetSize(&g_blank_prodinfo_file, ProdinfoSize);
+    rc = fsFileSetSize(&file, ProdinfoSize);
     if (R_FAILED(rc)) {
         std::abort();
     }
 
-    rc = fsFileWrite(&g_blank_prodinfo_file, 0, p, ProdinfoSize);
+    rc = fsFileWrite(&file, 0, p, ProdinfoSize);
     if (R_FAILED(rc)) {
         std::abort();
     }
 
-    rc = fsFileFlush(&g_blank_prodinfo_file);
+    rc = fsFileFlush(&file);
+    if (R_FAILED(rc)) {
+        std::abort();
+    }
+
+    fsFileClose(&file);
+
+    rc = fsFsOpenFile(&g_sd_filesystem, "/atmosphere/automatic_backups/prodinfo_blank.bin", FS_OPEN_READ, &g_blank_prodinfo_file);
     if (R_FAILED(rc)) {
         std::abort();
     }

--- a/stratosphere/ams_mitm/source/utils.cpp
+++ b/stratosphere/ams_mitm/source/utils.cpp
@@ -708,7 +708,7 @@ void Utils::CreateBlankProdinfoIfNeeded() {
 
         u8 data[data_size];
 
-        memset(&data, p ? g_cal0_backup[data_offset] : g_cal0_storage_backup[data_offset], data_size);
+        memcpy(&data, p ? g_cal0_backup[data_offset] : g_cal0_storage_backup[data_offset], data_size);
 
         u8 hash[0x20];
 

--- a/stratosphere/ams_mitm/source/utils.hpp
+++ b/stratosphere/ams_mitm/source/utils.hpp
@@ -90,6 +90,9 @@ class Utils {
         
         /* Error occurred. */
         static void RebootToFatalError(AtmosphereFatalErrorContext *ctx);
+
+        static FsFile GetBlankProdinfoFileHandle();
     private:
         static void RefreshConfiguration();
+        static void CreateBlankProdinfoIfNeeded();
 };

--- a/stratosphere/ams_mitm/source/utils.hpp
+++ b/stratosphere/ams_mitm/source/utils.hpp
@@ -91,9 +91,10 @@ class Utils {
         /* Error occurred. */
         static void RebootToFatalError(AtmosphereFatalErrorContext *ctx);
 
-        static Result OpenBlankProdinfoFile(FsFile *out);
+        static Result OpenBlankProdInfoFile(FsFile *out);
     private:
         static void RefreshConfiguration();
-        static void CreateBlankProdinfoIfNeeded();
-        static bool GetCAL0BackupBufferToBlank();
+        static void CreateBlankProdInfoIfNeeded();
+        static bool IsCal0Valid(u8* cal0);
+        static u8* GetCal0BufferToBlank();
 };

--- a/stratosphere/ams_mitm/source/utils.hpp
+++ b/stratosphere/ams_mitm/source/utils.hpp
@@ -91,8 +91,9 @@ class Utils {
         /* Error occurred. */
         static void RebootToFatalError(AtmosphereFatalErrorContext *ctx);
 
-        static FsFile GetBlankProdinfoFileHandle();
+        static Result OpenBlankProdinfoFile(FsFile *out);
     private:
         static void RefreshConfiguration();
         static void CreateBlankProdinfoIfNeeded();
+        static bool GetCAL0BackupBufferToBlank();
 };


### PR DESCRIPTION
This PR introduces a way for the user to "zero out" their console's PRODINFO partition, wiping console identification information, by means of redirecting the partition to a file stored on the SD card, instead of directly modifying the partition and risking the console. This is controlled by a global flag, ``blank_prodinfo``, which will redirect the partition if it's present, and return the normal partition if it is not.

This closes #165.