### PR TITLE
creport: Add 32 bits stack frames parsing support

### DIFF
--- a/stratosphere/creport/source/creport_debug_types.hpp
+++ b/stratosphere/creport/source/creport_debug_types.hpp
@@ -17,9 +17,14 @@
 #pragma once
 #include <switch.h>
 
-struct StackFrame {
+struct StackFrame64 {
     u64 fp;
     u64 lr;
+};
+
+struct StackFrame32 {
+    u32 fp;
+    u32 lr;
 };
 
 struct AttachProcessInfo {

--- a/stratosphere/creport/source/creport_debug_types.hpp
+++ b/stratosphere/creport/source/creport_debug_types.hpp
@@ -17,14 +17,15 @@
 #pragma once
 #include <switch.h>
 
-struct StackFrame64 {
-    u64 fp;
-    u64 lr;
-};
-
-struct StackFrame32 {
-    u32 fp;
-    u32 lr;
+union StackFrame {
+    struct {
+        u64 fp;
+        u64 lr;
+    } frame_64;
+    struct {
+        u32 fp;
+        u32 lr;
+    } frame_32;
 };
 
 struct AttachProcessInfo {

--- a/stratosphere/creport/source/creport_thread_info.cpp
+++ b/stratosphere/creport/source/creport_thread_info.cpp
@@ -115,14 +115,14 @@ bool ThreadInfo::ReadFromProcess(std::map<u64, u64> &tls_map, Handle debug_handl
             }
 
             /* Read a new frame. */
-            StackFrame64 cur_frame;
-            if (R_FAILED(svcReadDebugProcessMemory(&cur_frame, debug_handle, cur_fp, sizeof(StackFrame64)))) {
+            StackFrame cur_frame;
+            if (R_FAILED(svcReadDebugProcessMemory(&cur_frame, debug_handle, cur_fp, sizeof(cur_frame.frame_64)))) {
                 break;
             }
 
             /* Advance to the next frame. */
-            this->stack_trace[this->stack_trace_size++] = cur_frame.lr;
-            cur_fp = cur_frame.fp;
+            this->stack_trace[this->stack_trace_size++] = cur_frame.frame_64.lr;
+            cur_fp = cur_frame.frame_64.fp;
         }
     } else {
         for (unsigned int i = 0; i < sizeof(this->stack_trace)/sizeof(u64); i++) {
@@ -132,14 +132,14 @@ bool ThreadInfo::ReadFromProcess(std::map<u64, u64> &tls_map, Handle debug_handl
             }
 
             /* Read a new frame. */
-            StackFrame32 cur_frame;
-            if (R_FAILED(svcReadDebugProcessMemory(&cur_frame, debug_handle, cur_fp, sizeof(StackFrame32)))) {
+            StackFrame cur_frame;
+            if (R_FAILED(svcReadDebugProcessMemory(&cur_frame, debug_handle, cur_fp, sizeof(cur_frame.frame_32)))) {
                 break;
             }
 
             /* Advance to the next frame. */
-            this->stack_trace[this->stack_trace_size++] = cur_frame.lr;
-            cur_fp = cur_frame.fp;
+            this->stack_trace[this->stack_trace_size++] = cur_frame.frame_32.lr;
+            cur_fp = cur_frame.frame_32.fp;
         }
     }
 


### PR DESCRIPTION
Also fix FP, SP and LR registers being set wrongly by svcGetDebugThreadParam for 32 bits processes.