### PR TITLE
bpcmitm_main: Add missing header guard

### DIFF
--- a/stratosphere/ams_mitm/source/bpc_mitm/bpcmitm_main.hpp
+++ b/stratosphere/ams_mitm/source/bpc_mitm/bpcmitm_main.hpp
@@ -16,14 +16,7 @@
 
 #pragma once
 
-#include <cstdlib>
-#include <cstdint>
-#include <cstring>
-#include <malloc.h>
-
 #include <switch.h>
-#include <atmosphere.h>
-#include <stratosphere.hpp>
 
 constexpr u32 BpcMitmPriority = 32;
 constexpr u32 BpcMitmStackSize = 0x8000;

--- a/stratosphere/ams_mitm/source/bpc_mitm/bpcmitm_main.hpp
+++ b/stratosphere/ams_mitm/source/bpc_mitm/bpcmitm_main.hpp
@@ -13,7 +13,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
- 
+
+#pragma once
+
 #include <cstdlib>
 #include <cstdint>
 #include <cstring>


### PR DESCRIPTION
Prevents any potential double inclusion issues from occurring. While we're at it, we can also tidy up the header's included files as well, given only the type definitions from <switch.h> are used by it. The corresponding cpp file already includes these headers.