### PR TITLE
sept: use python2 in Makefile

### DIFF
--- a/sept/sept-secondary/Makefile
+++ b/sept/sept-secondary/Makefile
@@ -153,7 +153,7 @@ DEPENDS	:=	$(OFILES:.o=.d)
 all	:	$(OUTPUT).enc
 
 $(OUTPUT).enc	:	$(OUTPUT).bin
-	@python $(TOPDIR)/sept_sign.py $< $@
+	@python2 $(TOPDIR)/sept_sign.py $< $@
 	@echo built ... $(notdir $@)
 
 $(OUTPUT).bin	:	$(OUTPUT).elf


### PR DESCRIPTION
Makes life easier for distros like Arch where `python` defaults to Python 3.