### PR TITLE
Enable ccache

### DIFF
--- a/emummc/Makefile
+++ b/emummc/Makefile
@@ -32,6 +32,8 @@ CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++17
 
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=$(DEVKITPRO)/libnx/switch.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
+CXX		:= `which ccache` $(CXX)
+CC		:= `which ccache` $(CC)
 
 ifneq ($(BUILD),$(notdir $(CURDIR)))
 

--- a/exosphere/Makefile
+++ b/exosphere/Makefile
@@ -56,6 +56,8 @@ ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=$(TOPDIR)/linker.specs -nostartfiles -nostdlib -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
 LIBS	:=
+CXX		:= `which ccache` $(CXX)
+CC		:= `which ccache` $(CC)
 
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing

--- a/exosphere/lp0fw/Makefile
+++ b/exosphere/lp0fw/Makefile
@@ -47,6 +47,8 @@ ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=$(TOPDIR)/linker.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
 LIBS	:=
+CXX		:= `which ccache` $(CXX)
+CC		:= `which ccache` $(CC)
 
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing

--- a/exosphere/rebootstub/Makefile
+++ b/exosphere/rebootstub/Makefile
@@ -47,6 +47,8 @@ ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=$(TOPDIR)/linker.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
 LIBS	:=
+CXX		:= `which ccache` $(CXX)
+CC		:= `which ccache` $(CC)
 
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing

--- a/exosphere/sc7fw/Makefile
+++ b/exosphere/sc7fw/Makefile
@@ -47,6 +47,8 @@ ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=$(TOPDIR)/linker.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
 LIBS	:=
+CXX		:= `which ccache` $(CXX)
+CC		:= `which ccache` $(CC)
 
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing

--- a/fusee/fusee-primary/Makefile
+++ b/fusee/fusee-primary/Makefile
@@ -57,6 +57,8 @@ ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=$(TOPDIR)/linker.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
 LIBS	:=
+CXX		:= `which ccache` $(CXX)LIBS
+CC		:= `which ccache` $(CC)
 
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing

--- a/fusee/fusee-secondary/Makefile
+++ b/fusee/fusee-secondary/Makefile
@@ -66,6 +66,8 @@ ASFLAGS	:=	-g $(ARCH) $(INCLUDE) $(DEFINES)
 LDFLAGS	=	-specs=$(TOPDIR)/linker.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
 LIBS	:=
+CXX		:= `which ccache` $(CXX)
+CC		:= `which ccache` $(CC)
 
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing

--- a/sept/sept-primary/Makefile
+++ b/sept/sept-primary/Makefile
@@ -57,6 +57,8 @@ ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=$(TOPDIR)/linker.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
 LIBS	:=
+CXX		:= `which ccache` $(CXX)
+CC		:= `which ccache` $(CC)
 
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing
@@ -66,7 +68,7 @@ LIBDIRS	:=
 
 
 #---------------------------------------------------------------------------------
-# no real need to edit anything past this point unless you need to add additional
+# no real need to edit anything past this point unless you need to add additiona
 # rules for different file extensions
 #---------------------------------------------------------------------------------
 ifneq ($(BUILD),$(notdir $(CURDIR)))

--- a/sept/sept-primary/Makefile
+++ b/sept/sept-primary/Makefile
@@ -68,7 +68,7 @@ LIBDIRS	:=
 
 
 #---------------------------------------------------------------------------------
-# no real need to edit anything past this point unless you need to add additiona
+# no real need to edit anything past this point unless you need to add additional
 # rules for different file extensions
 #---------------------------------------------------------------------------------
 ifneq ($(BUILD),$(notdir $(CURDIR)))

--- a/sept/sept-secondary/Makefile
+++ b/sept/sept-secondary/Makefile
@@ -57,6 +57,8 @@ ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=$(TOPDIR)/linker.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
 LIBS	:=
+CXX		:= `which ccache` $(CXX)
+CC		:= `which ccache` $(CC)
 
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing

--- a/sept/sept-secondary/key_derivation/Makefile
+++ b/sept/sept-secondary/key_derivation/Makefile
@@ -47,6 +47,8 @@ ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=$(TOPDIR)/linker.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
 LIBS	:=
+CXX		:= `which ccache` $(CXX)
+CC		:= `which ccache` $(CC)
 
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing

--- a/stratosphere/ams_mitm/Makefile
+++ b/stratosphere/ams_mitm/Makefile
@@ -49,7 +49,8 @@ ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=$(DEVKITPRO)/libnx/switch.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
 LIBS	:= -lstratosphere -lnx
-
+CXX		:= `which ccache` $(CXX)
+CC		:= `which ccache` $(CC)
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing
 # include and lib

--- a/stratosphere/boot/Makefile
+++ b/stratosphere/boot/Makefile
@@ -56,7 +56,8 @@ ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=$(DEVKITPRO)/libnx/switch.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
 LIBS	:= -lstratosphere -lnx
-
+CXX		:= `which ccache` $(CXX)
+CC		:= `which ccache` $(CC)
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing
 # include and lib

--- a/stratosphere/creport/Makefile
+++ b/stratosphere/creport/Makefile
@@ -49,7 +49,8 @@ ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=$(DEVKITPRO)/libnx/switch.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
 LIBS	:= -lstratosphere -lnx
-
+CXX		:= `which ccache` $(CXX)
+CC		:= `which ccache` $(CC)
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing
 # include and lib

--- a/stratosphere/dmnt/Makefile
+++ b/stratosphere/dmnt/Makefile
@@ -49,7 +49,8 @@ ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=$(DEVKITPRO)/libnx/switch.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
 LIBS	:= -lstratosphere -lnx
-
+CXX		:= `which ccache` $(CXX)
+CC		:= `which ccache` $(CC)
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing
 # include and lib

--- a/stratosphere/eclct.stub/Makefile
+++ b/stratosphere/eclct.stub/Makefile
@@ -49,7 +49,8 @@ ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=$(DEVKITPRO)/libnx/switch.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
 LIBS	:= -lstratosphere -lnx
-
+CXX		:= `which ccache` $(CXX)
+CC		:= `which ccache` $(CC)
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing
 # include and lib

--- a/stratosphere/fatal/Makefile
+++ b/stratosphere/fatal/Makefile
@@ -49,7 +49,8 @@ ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=$(DEVKITPRO)/libnx/switch.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
 LIBS	:= `freetype-config --libs` -lstratosphere -lnx
-
+CXX		:= `which ccache` $(CXX)
+CC		:= `which ccache` $(CC)
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing
 # include and lib

--- a/stratosphere/libstratosphere/Makefile
+++ b/stratosphere/libstratosphere/Makefile
@@ -38,7 +38,8 @@ ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=$(DEVKITPRO)/libnx/switch.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
 LIBS	:= -lnx
-
+CXX		:= `which ccache` $(CXX)
+CC		:= `which ccache` $(CC)
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing
 # include and lib

--- a/stratosphere/loader/Makefile
+++ b/stratosphere/loader/Makefile
@@ -49,7 +49,8 @@ ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=$(DEVKITPRO)/libnx/switch.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
 LIBS	:= -lstratosphere -lnx
-
+CXX		:= `which ccache` $(CXX)
+CC		:= `which ccache` $(CC)
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing
 # include and lib

--- a/stratosphere/pm/Makefile
+++ b/stratosphere/pm/Makefile
@@ -49,7 +49,8 @@ ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=$(DEVKITPRO)/libnx/switch.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
 LIBS	:= -lstratosphere -lnx
-
+CXX		:= `which ccache` $(CXX)
+CC		:= `which ccache` $(CC)
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing
 # include and lib

--- a/stratosphere/ro/Makefile
+++ b/stratosphere/ro/Makefile
@@ -49,7 +49,8 @@ ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=$(DEVKITPRO)/libnx/switch.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
 LIBS	:= -lstratosphere -lnx
-
+CXX		:= `which ccache` $(CXX)
+CC		:= `which ccache` $(CC)
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing
 # include and lib

--- a/stratosphere/sm/Makefile
+++ b/stratosphere/sm/Makefile
@@ -49,7 +49,8 @@ ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=$(DEVKITPRO)/libnx/switch.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
 LIBS	:= -lstratosphere -lnx
-
+CXX		:= `which ccache` $(CXX)
+CC		:= `which ccache` $(CC)
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing
 # include and lib

--- a/stratosphere/spl/Makefile
+++ b/stratosphere/spl/Makefile
@@ -49,7 +49,8 @@ ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=$(DEVKITPRO)/libnx/switch.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
 LIBS	:= -lstratosphere -lnx
-
+CXX		:= `which ccache` $(CXX)
+CC		:= `which ccache` $(CC)
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing
 # include and lib

--- a/thermosphere/Makefile
+++ b/thermosphere/Makefile
@@ -56,7 +56,8 @@ ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=$(TOPDIR)/linker.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
 LIBS	:=
-
+CXX		:= `which ccache` $(CXX)
+CC		:= `which ccache` $(CC)
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing
 # include and lib

--- a/troposphere/reboot_to_payload/Makefile
+++ b/troposphere/reboot_to_payload/Makefile
@@ -57,7 +57,8 @@ ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=$(DEVKITPRO)/libnx/switch.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
 LIBS	:= -lnx
-
+CXX		:= `which ccache` $(CXX)
+CC		:= `which ccache` $(CC)
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing
 # include and lib


### PR DESCRIPTION
This pull enables ccache for atmosphere compilation on machines with ccache in place making it faster to compile.  This does nothing on machines without ccache.   I see no reason not to have it.  This no effect on output code.