### PR TITLE
Allow system, application and applet memory to be set manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,3 @@
-# WHY DOES THIS FORK EXIST
-All this fork does is allows the size of the System memory pool to be changed
-
-## *START OF ORIGINAL README*
-
 ![Banner](img/banner.png?raw=true)
 =====
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 ![Banner](img/banner.png?raw=true)
 =====
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# WHY DOES THIS FORK EXIST
+All this fork does is allows the size of the System memory pool to be changed
+
+## *START OF ORIGINAL README*
 
 ![Banner](img/banner.png?raw=true)
 =====

--- a/common/defaults/system_settings.ini
+++ b/common/defaults/system_settings.ini
@@ -29,6 +29,23 @@ dmnt_always_save_cheat_toggles = u8!0x0
 ; NOTE: EXPERIMENTAL
 ; If you do not know what you are doing, do not touch this yet.
 fsmitm_redirect_saves_to_sd = u8!0x0
+; Enable changing the raw memory values assigned to system, application and applet
+; These values should and must add up to 4089, however the system does no checking
+; By default, the Process Manager determines these values
+; This requires a reboot to take effect
+manual_memory_control = u8!0x0
+; Set amount of memory assigned to the system in mb
+; Only used when `manual_memory_control` is true
+; Default is 293 mb
+system_memory = u64!0x0125
+; Set amount of memory assigned to applications in mb
+; Only used when `manual_memory_control` is true
+; Default is 3285 mb
+application_memory = u64!0x0CD5
+; Set amount of memory assigned to applets in mb
+; Only used when `manual_memory_control` is true
+; Default is 511 mb
+applet_memory = u64!0x01FF
 [hbloader]
 ; Controls the size of the homebrew heap when running as applet.
 ; If set to zero, all available applet memory is used as heap.

--- a/common/defaults/system_settings.ini
+++ b/common/defaults/system_settings.ini
@@ -32,6 +32,7 @@ fsmitm_redirect_saves_to_sd = u8!0x0
 ; Enable changing the raw memory values assigned to system, application and applet
 ; These values should and must add up to 4089, however the system does no checking
 ; By default, the Process Manager determines these values
+; This setting is advanced and not recommended for unfamiliar users
 ; This requires a reboot to take effect
 manual_memory_control = u8!0x0
 ; Set amount of memory assigned to the system in mb

--- a/stratosphere/pm/source/impl/pm_resource_manager.cpp
+++ b/stratosphere/pm/source/impl/pm_resource_manager.cpp
@@ -41,7 +41,7 @@ namespace sts::pm::resource {
         constexpr size_t ExtraSystemSessionCount600  = 100;
         constexpr size_t ReservedMemorySize600       = 5 * Megabyte;
 
-        /* Atmosphere always allocates 24 extra megabytes for system usage. */
+        /* The amount of extra memory Atmosphere needs can be specified by the main settings file, but this is the default */
         constexpr size_t ExtraSystemMemorySizeAtmosphere = 24 * Megabyte;
 
         /* Globals. */
@@ -267,9 +267,28 @@ namespace sts::pm::resource {
         /* Actually set resource limits. */
         {
             std::scoped_lock lk(g_resource_limit_lock);
-
-            for (size_t group = 0; group < ResourceLimitGroup_Count; group++) {
-                R_ASSERT(SetResourceLimitLimitValues(static_cast<ResourceLimitGroup>(group), g_memory_resource_limits[g_memory_arrangement][group]));
+            spl::MemoryArrangement_Standard
+                
+            u8 SetMemoryManually;
+            R_ASSERT(setsysGetSettingsItemValueSize("atmosphere", "manual_memory_control", &SetMemoryManually));
+            if (!SetMemoryManually) {
+                /* Memory corresponds to the chosen `g_memory_arrangement`. */
+                /* Default. */
+                for (size_t group = 0; group < ResourceLimitGroup_Count; group++) {
+                    R_ASSERT(SetResourceLimitLimitValues(static_cast<ResourceLimitGroup>(group), g_memory_resource_limits[g_memory_arrangement][group]));
+                }
+            } else {
+                /* Memory info was chosen by the user. */
+                u64 systemSize;
+                u64 applicationSize;
+                u64 appletSize;
+                R_ASSERT(setsysGetSettingsItemValueSize("atmosphere", "system_memory", &systemSize));
+                R_ASSERT(setsysGetSettingsItemValueSize("atmosphere", "application_memory", &applicationSize));
+                R_ASSERT(setsysGetSettingsItemValueSize("atmosphere", "applet_memory", &appletSize));
+                /* Set all memory values. */
+                R_ASSERT(SetResourceLimitLimitValues(static_cast<ResourceLimitGroup>(ResourceLimitGroup_System), systemSize * Megabyte);
+                R_ASSERT(SetResourceLimitLimitValues(static_cast<ResourceLimitGroup>(ResourceLimitGroup_Application), applicationSize * Megabyte);
+                R_ASSERT(SetResourceLimitLimitValues(static_cast<ResourceLimitGroup>(ResourceLimitGroup_Applet), appletSize * Megabyte);
             }
         }
 

--- a/stratosphere/pm/source/impl/pm_resource_manager.cpp
+++ b/stratosphere/pm/source/impl/pm_resource_manager.cpp
@@ -269,8 +269,8 @@ namespace sts::pm::resource {
             std::scoped_lock lk(g_resource_limit_lock);
             spl::MemoryArrangement_Standard
                 
-            u8 SetMemoryManually;
-            R_ASSERT(setsysGetSettingsItemValueSize("atmosphere", "manual_memory_control", &SetMemoryManually));
+            bool SetMemoryManually;
+            R_ASSERT(setsysGetSettingsItemValueSize("atmosphere", "manual_memory_control", &SetMemoryManually, sizeof(SetMemoryManually)));
             if (!SetMemoryManually) {
                 /* Memory corresponds to the chosen `g_memory_arrangement`. */
                 /* Default. */
@@ -282,9 +282,9 @@ namespace sts::pm::resource {
                 u64 systemSize;
                 u64 applicationSize;
                 u64 appletSize;
-                R_ASSERT(setsysGetSettingsItemValueSize("atmosphere", "system_memory", &systemSize));
-                R_ASSERT(setsysGetSettingsItemValueSize("atmosphere", "application_memory", &applicationSize));
-                R_ASSERT(setsysGetSettingsItemValueSize("atmosphere", "applet_memory", &appletSize));
+                R_ASSERT(setsysGetSettingsItemValueSize("atmosphere", "system_memory", &systemSize, sizeof(systemSize)));
+                R_ASSERT(setsysGetSettingsItemValueSize("atmosphere", "application_memory", &applicationSize, sizeof(applicationSize)));
+                R_ASSERT(setsysGetSettingsItemValueSize("atmosphere", "applet_memory", &appletSize, sizeof(appletSize)));
                 /* Set all memory values. */
                 R_ASSERT(SetResourceLimitLimitValues(static_cast<ResourceLimitGroup>(ResourceLimitGroup_System), systemSize * Megabyte);
                 R_ASSERT(SetResourceLimitLimitValues(static_cast<ResourceLimitGroup>(ResourceLimitGroup_Application), applicationSize * Megabyte);

--- a/stratosphere/pm/source/impl/pm_resource_manager.cpp
+++ b/stratosphere/pm/source/impl/pm_resource_manager.cpp
@@ -270,7 +270,7 @@ namespace sts::pm::resource {
             spl::MemoryArrangement_Standard
                 
             bool SetMemoryManually;
-            R_ASSERT(setsysGetSettingsItemValueSize("atmosphere", "manual_memory_control", &SetMemoryManually, sizeof(SetMemoryManually)));
+            R_ASSERT(setsysGetSettingsItemValue("atmosphere", "manual_memory_control", &SetMemoryManually, sizeof(SetMemoryManually)));
             if (!SetMemoryManually) {
                 /* Memory corresponds to the chosen `g_memory_arrangement`. */
                 /* Default. */
@@ -282,9 +282,9 @@ namespace sts::pm::resource {
                 u64 systemSize;
                 u64 applicationSize;
                 u64 appletSize;
-                R_ASSERT(setsysGetSettingsItemValueSize("atmosphere", "system_memory", &systemSize, sizeof(systemSize)));
-                R_ASSERT(setsysGetSettingsItemValueSize("atmosphere", "application_memory", &applicationSize, sizeof(applicationSize)));
-                R_ASSERT(setsysGetSettingsItemValueSize("atmosphere", "applet_memory", &appletSize, sizeof(appletSize)));
+                R_ASSERT(setsysGetSettingsItemValue("atmosphere", "system_memory", &systemSize, sizeof(systemSize)));
+                R_ASSERT(setsysGetSettingsItemValue("atmosphere", "application_memory", &applicationSize, sizeof(applicationSize)));
+                R_ASSERT(setsysGetSettingsItemValue("atmosphere", "applet_memory", &appletSize, sizeof(appletSize)));
                 /* Set all memory values. */
                 R_ASSERT(SetResourceLimitLimitValues(static_cast<ResourceLimitGroup>(ResourceLimitGroup_System), systemSize * Megabyte);
                 R_ASSERT(SetResourceLimitLimitValues(static_cast<ResourceLimitGroup>(ResourceLimitGroup_Application), applicationSize * Megabyte);


### PR DESCRIPTION
In `system_settings.ini`, you can now set memory manually through these settings:

`atmosphere:manual_memory_control`: Whether to read the memory values manually or generate them based on various hardware details
`atmosphere:system_memory`: System memory in Mb
`atmosphere:application_memory`: Application memory in Mb
`atmosphere:applet_memory`: Applet memory in Mb

These settings are marked as advanced and dangerous.