### PR TITLE
Add ini option to disable cal0 write protection

### DIFF
--- a/config_templates/system_settings.ini
+++ b/config_templates/system_settings.ini
@@ -26,6 +26,9 @@
 ; Enable reading the CAL0 partition for HBL.
 ; This is probably undesirable for normal usage.
 ; enable_hbl_cal_read = u8!0x0
+; Disable CAL0 write-protection
+; This is almost certainly undesirable and dangerous for normal usage
+; disable_cal_write = u8!0x0 WARRANTY VOID IF CHANGED - YOU HAVE BEEN WARNED
 ; Controls whether fs.mitm should redirect save files
 ; to directories on the sd card.
 ; 0 = Do not redirect, 1 = Redirect.

--- a/stratosphere/ams_mitm/source/set_mitm/settings_sd_kvs.cpp
+++ b/stratosphere/ams_mitm/source/set_mitm/settings_sd_kvs.cpp
@@ -332,6 +332,10 @@ namespace ams::settings::fwdbg {
             /* This is probably undesirable for normal usage. */
             R_ABORT_UNLESS(ParseSettingsItemValue("atmosphere", "enable_hbl_cal_read", "u8!0x0"));
 
+            /* Disable CAL0 write-protection */
+            /* This is almost certainly undesirable and dangerous for normal usage. */
+            R_ABORT_UNLESS(ParseSettingsItemValue("atmosphere", "disable_cal_write", "u8!0x0"));
+
             /* Controls whether dmnt cheats should be toggled on or off by */
             /* default. 1 = toggled on by default, 0 = toggled off by default. */
             R_ABORT_UNLESS(ParseSettingsItemValue("atmosphere", "dmnt_cheats_enabled_by_default", "u8!0x1"));


### PR DESCRIPTION
This pull request makes write-protection on cal0 configurable by ini. In particular, this is desirable so that the user can blank their PRODINFO on their emunand, which practically severs the connection to Nintendo's servers.

I've tried to put up sufficiently many warnings to dissuade the average user from toggling it without being aware of the repercussions.