### PR TITLE
Add stack overflow detection to fatal error code

### DIFF
--- a/fusee/fusee-primary/src/panic.c
+++ b/fusee/fusee-primary/src/panic.c
@@ -42,6 +42,8 @@ static const char *get_error_desc_str(uint32_t error_desc) {
             return "SError";
         case 0x301:
             return "Bad SVC";
+        case 0xFFD:
+	        return "Stack overflow";
         case 0xFFE:
             return "std::abort() called";
         default:

--- a/libraries/libstratosphere/include/stratosphere/ams/ams_types.hpp
+++ b/libraries/libstratosphere/include/stratosphere/ams/ams_types.hpp
@@ -73,6 +73,7 @@ namespace ams {
         static constexpr uintptr_t StdAbortMagicAddress = 0x8;
         static constexpr u64       StdAbortMagicValue = 0xA55AF00DDEADCAFEul;
         static constexpr u32       StdAbortErrorDesc = 0xFFE;
+        static constexpr u32       StackOverflowErrorDesc = 0xFFD;
         static constexpr u32       DataAbortErrorDesc = 0x101;
         static constexpr u32       Magic = util::FourCC<'A', 'F', 'E', '2'>::Code;
 


### PR DESCRIPTION
Saves some two minutes of looking at a fatal error report and a disassembly to figure out that something daborted because the stack overflowed on a sequence like this and that you might need to increase stack size:
```
sub sp, sp, 0x4f0
stp x29, x30, [sp]
```
