### PR TITLE
fatal: Fix autoreboot logic (#959)

### DIFF
--- a/stratosphere/fatal/source/fatal_config.hpp
+++ b/stratosphere/fatal/source/fatal_config.hpp
@@ -68,11 +68,11 @@ namespace ams::fatal::srv {
             }
 
             u64 GetQuestRebootTimeoutInterval() const {
-                return this->quest_reboot_interval_second * 1'000'000'000ul;
+                return this->quest_reboot_interval_second * 1'000ul;
             }
 
             u64 GetFatalRebootTimeoutInterval() const {
-                return this->fatal_auto_reboot_interval * 1'000'000ul;
+                return this->fatal_auto_reboot_interval;
             }
 
             const char *GetErrorMessage() const {

--- a/stratosphere/fatal/source/fatal_task_power.cpp
+++ b/stratosphere/fatal/source/fatal_task_power.cpp
@@ -55,15 +55,15 @@ namespace ams::fatal::srv {
             private:
                 os::Tick start_tick;
                 bool flag;
-                s32 interval;
+                s64 interval;
             public:
-                RebootTimingObserver(bool flag, s32 interval) : start_tick(os::GetSystemTick()), flag(flag), interval(interval) {
+                RebootTimingObserver(bool flag, s64 interval) : start_tick(os::GetSystemTick()), flag(flag), interval(interval) {
                     /* ... */
                 }
 
                 bool IsRebootTiming() const {
                     auto current_tick = os::GetSystemTick();
-                    return this->flag && (current_tick - this->start_tick).ToTimeSpan().GetSeconds() >= this->interval;
+                    return this->flag && (current_tick - this->start_tick).ToTimeSpan().GetMilliSeconds() >= this->interval;
                 }
         };
 


### PR DESCRIPTION
I assumed from the existing code that quest_reboot_interval_second is stored in seconds, couldn't find it on switchbrew.
Tested and working.