### PR TITLE
Add Github Workflow and Build Status

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -1,0 +1,53 @@
+name: Atmosphere Build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: ubuntu-20.04
+    runs-on: ubuntu-20.04
+    container: devkitpro/devkita64_devkitarm
+
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+
+    - name: Copy source list
+      run: sudo cp -r sources.list /etc/apt/
+      working-directory: ./workflow_files
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y dirmngr --install-recommends --allow-unauthenticated
+        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32
+        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 871920D1991BC93C
+        sudo apt-get update
+        sudo apt-get install -y -f
+        sudo dpkg --configure -a
+        sudo apt-get upgrade -y --with-new-pkgs
+        sudo apt-get install -y lz4
+        sudo apt-get install -y gawk
+        sudo apt-get install python-is-python3
+        sudo apt-get install python3-pip --yes
+        sudo pip3 install lz4
+        sudo pip3 install pycryptodome
+
+    - name: Checkout libnx
+      uses: actions/checkout@v2
+      with:
+        repository: switchbrew/libnx
+        path: libnx
+
+    - name: Make libnx
+      run: make
+      working-directory: ${{ github.workspace }}/libnx
+
+    - name: Install libnx
+      run: make install
+      working-directory: ${{ github.workspace }}/libnx
+
+    - name: Build
+      run: |
+        make -j2

--- a/README.md
+++ b/README.md
@@ -7,8 +7,16 @@
 
 Atmosphère is a work-in-progress customized firmware for the Nintendo Switch.
 
-Components
-=====
+# Build Status
+
+|Build status: 	| [![Build Status][Build]][Actions] 
+|---------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+
+[Actions]: https://github.com/Atmosphere-NX/Atmosphere/actions
+[Build]: https://github.com/Atmosphere-NX/Atmosphere/workflows/Atmosphere%20Build/badge.svg
+
+
+# Components
 
 Atmosphère consists of multiple components, each of which replaces/modifies a different component of the system:
 
@@ -19,8 +27,8 @@ Atmosphère consists of multiple components, each of which replaces/modifies a d
 * Stratosphère: Custom Sysmodule(s), both Rosalina style to extend the kernel/provide new features, and of the loader reimplementation style to hook important system actions
 * Troposphère: Application-level Horizon OS patches, used to implement desirable CFW features
 
-Licensing
-=====
+
+# Licensing
 
 This software is licensed under the terms of the GPLv2, with exemptions for specific projects noted below.
 
@@ -30,8 +38,8 @@ Exemptions:
 * The [yuzu Nintendo Switch emulator](https://github.com/yuzu-emu/yuzu) and the [Ryujinx Team and Contributors](https://github.com/orgs/Ryujinx) are exempt from GPLv2 licensing. They are permitted, each at their individual discretion, to instead license any source code authored for the Atmosphère project as either GPLv2 or later or the [MIT license](https://github.com/Atmosphere-NX/Atmosphere/blob/master/docs/licensing_exemptions/MIT_LICENSE). In doing so, they may alter, supplement, or entirely remove the copyright notice for each file they choose to relicense. Neither the Atmosphère project nor its individual contributors shall assert their moral rights against any of the aforementioned projects.
 * [Nintendo](https://github.com/Nintendo) is exempt from GPLv2 licensing and may (at its option) instead license any source code authored for the Atmosphère project under the Zero-Clause BSD license.
 
-Credits
-=====
+
+# Credits
 
 Atmosphère is currently being developed and maintained by __SciresM__, __TuxSH__, __hexkyz__, and __fincs__.<br>
 In no particular order, we credit the following for their invaluable contributions:

--- a/workflow_files/sources.list
+++ b/workflow_files/sources.list
@@ -1,0 +1,14 @@
+deb http://archive.ubuntu.com/ubuntu/ focal main restricted universe multiverse
+deb-src http://archive.ubuntu.com/ubuntu/ focal main restricted universe multiverse
+
+deb http://archive.ubuntu.com/ubuntu/ focal-updates main restricted universe multiverse
+deb-src http://archive.ubuntu.com/ubuntu/ focal-updates main restricted universe multiverse
+
+deb http://archive.ubuntu.com/ubuntu/ focal-security main restricted universe multiverse
+deb-src http://archive.ubuntu.com/ubuntu/ focal-security main restricted universe multiverse
+
+deb http://archive.ubuntu.com/ubuntu/ focal-backports main restricted universe multiverse
+deb-src http://archive.ubuntu.com/ubuntu/ focal-backports main restricted universe multiverse
+
+deb http://archive.canonical.com/ubuntu focal partner
+deb-src http://archive.canonical.com/ubuntu focal partner


### PR DESCRIPTION
- Adds a Github Workflow
- Shows the Build Status of the Github Workflow on the main page


You can view the Build Status button on my Github branch, the button will only be available when the commit has been merged and the build on has been completed:
https://github.com/bladeoner/Atmosphere/tree/workflow

At this moment I triggered a build which will successfully complete which can be seen here:
https://github.com/bladeoner/Atmosphere/actions