### PR TITLE
docs/building: missing required lib glm

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -12,6 +12,7 @@ Building Atmosphère is a very straightforward process that relies almost exclus
 
 2. Install the following packages via (dkp-)pacman:
     + `switch-dev`
+    + `switch-glm`
     + `switch-libjpeg-turbo`
     + `devkitARM`
     + `devkitarm-rules`


### PR DESCRIPTION
During compilation the header was missing, adding the package to the list.