### PR TITLE
fix typo in KServerPort::Destroy()

### DIFF
--- a/libraries/libmesosphere/source/kern_k_server_port.cpp
+++ b/libraries/libmesosphere/source/kern_k_server_port.cpp
@@ -77,7 +77,7 @@ namespace ams::kern {
 
     void KServerPort::Destroy() {
         /* Note with our parent that we're closed. */
-        m_parent->OnClientClosed();
+        m_parent->OnServerClosed();
 
         /* Perform necessary cleanup of our session lists. */
         this->CleanupSessions();


### PR DESCRIPTION
Likely doesn't impact anything, but I assume this was unintended.