### PR TITLE
Add lz4 dependency to the build instructions

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -5,7 +5,8 @@ Building Atmosphère is a very straightforward process that relies almost exclus
 + [devkitA64](https://devkitpro.org)
 + [devkitARM](https://devkitpro.org)
 + [Python 2](https://www.python.org) (Python 3 may work as well, but this is not guaranteed)
-+ [PyCryptodome](https://pypi.org/project/pycryptodome) (optional)
++ [LZ4 (Python library)](https://pypi.org/project/lz4)
++ [PyCryptodome (Python library)](https://pypi.org/project/pycryptodome) (optional)
 
 ## Instructions
 1. Follow the guide located [here](https://devkitpro.org/wiki/Getting_Started) to install and configure all the tools necessary for the build process. 
@@ -17,12 +18,15 @@ Building Atmosphère is a very straightforward process that relies almost exclus
     + `devkitARM`
     + `devkitarm-rules`
 
-3. (Optional) In order to build [sept](components/sept.md) the pycryptodome PyPi package is required, which can be installed by running `pip install pycryptodome` under the installed Python environment of your choice or by installing the complete zip package to support the `make dist` recipe. This is an optional step included for advanced users who have the ability to provide the necessary encryption/signing keys themselves.
+3. Install the following library via python's package manager `pip`, required by [exosphere](components/exosphere.md):
+    + `lz4`
 
-4. It is, instead, possible to build [sept](components/sept.md) by providing previously encrypted/signed binaries distributed by official Atmosphère release packages. In order to do so, export the following variables in your current environment:
+4. (Optional) In order to build [sept](components/sept.md) the pycryptodome PyPi package is required, which can be installed by running `pip install pycryptodome` under the installed Python environment of your choice or by installing the complete zip package to support the `make dist` recipe. This is an optional step included for advanced users who have the ability to provide the necessary encryption/signing keys themselves.
+
+5. It is, instead, possible to build [sept](components/sept.md) by providing previously encrypted/signed binaries distributed by official Atmosphère release packages. In order to do so, export the following variables in your current environment:
     + `SEPT_00_ENC_PATH` (must point to the `sept-secondary_00.enc` file)
     + `SEPT_01_ENC_PATH` (must point to the `sept-secondary_01.enc` file)
     + `SEPT_DEV_00_ENC_PATH` (must point to the `sept-secondary_dev_00.enc` file)
     + `SEPT_DEV_01_ENC_PATH` (must point to the `sept-secondary_dev_01.enc` file)
 
-5. Finally, clone the Atmosphère repository and run `make` under its root directory.
+6. Finally, clone the Atmosphère repository and run `make` under its root directory.

--- a/docs/building.md
+++ b/docs/building.md
@@ -5,8 +5,8 @@ Building Atmosphère is a very straightforward process that relies almost exclus
 + [devkitA64](https://devkitpro.org)
 + [devkitARM](https://devkitpro.org)
 + [Python 2](https://www.python.org) (Python 3 may work as well, but this is not guaranteed)
-+ [LZ4 (Python library)](https://pypi.org/project/lz4)
-+ [PyCryptodome (Python library)](https://pypi.org/project/pycryptodome) (optional)
++ [LZ4](https://pypi.org/project/lz4)
++ [PyCryptodome](https://pypi.org/project/pycryptodome) (optional)
 
 ## Instructions
 1. Follow the guide located [here](https://devkitpro.org/wiki/Getting_Started) to install and configure all the tools necessary for the build process. 


### PR DESCRIPTION
At build-time of exosphere, the `split_program.py` script is called.
It requires python module `lz4` -> https://github.com/Atmosphere-NX/Atmosphere/blob/master/exosphere/program/split_program.py

Adding lz4 to the building.md documentation.