### PR TITLE
sm: implement accurate request deferral semantics

### DIFF
--- a/libraries/libstratosphere/include/stratosphere/sf/hipc/sf_hipc_server_manager.hpp
+++ b/libraries/libstratosphere/include/stratosphere/sf/hipc/sf_hipc_server_manager.hpp
@@ -128,10 +128,6 @@ namespace ams::sf::hipc {
 
             os::Mutex waitlist_mutex;
             os::WaitableManagerType waitlist;
-
-            os::Mutex deferred_session_mutex;
-            using DeferredSessionList = typename util::IntrusiveListMemberTraits<&ServerSession::deferred_list_node>::ListType;
-            DeferredSessionList deferred_session_list;
         private:
             virtual void RegisterSessionToWaitList(ServerSession *session) override final;
             void RegisterToWaitList(os::WaitableHolderType *holder);
@@ -142,8 +138,6 @@ namespace ams::sf::hipc {
             Result ProcessForServer(os::WaitableHolderType *holder);
             Result ProcessForMitmServer(os::WaitableHolderType *holder);
             Result ProcessForSession(os::WaitableHolderType *holder);
-
-            void   ProcessDeferredSessions();
 
             template<typename Interface, auto MakeShared>
             void RegisterServerImpl(Handle port_handle, sm::ServiceName service_name, bool managed, cmif::ServiceObjectHolder &&static_holder) {
@@ -176,7 +170,7 @@ namespace ams::sf::hipc {
             ServerManagerBase(DomainEntryStorage *entry_storage, size_t entry_count) :
                 ServerDomainSessionManager(entry_storage, entry_count),
                 request_stop_event(os::EventClearMode_ManualClear), notify_event(os::EventClearMode_ManualClear),
-                waitable_selection_mutex(false), waitlist_mutex(false), deferred_session_mutex(false)
+                waitable_selection_mutex(false), waitlist_mutex(false)
             {
                 /* Link waitables. */
                 os::InitializeWaitableManager(std::addressof(this->waitable_manager));

--- a/libraries/libstratosphere/include/stratosphere/sf/hipc/sf_hipc_server_session_manager.hpp
+++ b/libraries/libstratosphere/include/stratosphere/sf/hipc/sf_hipc_server_session_manager.hpp
@@ -45,7 +45,6 @@ namespace ams::sf::hipc {
         NON_COPYABLE(ServerSession);
         NON_MOVEABLE(ServerSession);
         private:
-            util::IntrusiveListNode deferred_list_node;
             cmif::ServiceObjectHolder srv_obj_holder;
             cmif::PointerAndSize pointer_buffer;
             cmif::PointerAndSize saved_message;

--- a/stratosphere/sm/source/impl/sm_wait_list.cpp
+++ b/stratosphere/sm/source/impl/sm_wait_list.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2018-2020 Atmosphère-NX
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <stratosphere.hpp>
+#include "sm_wait_list.hpp"
+
+namespace ams::sm::impl {
+
+    namespace {
+
+        static constexpr size_t DeferredSessionCountMax = 0x40;
+
+        struct WaitListEntry {
+            sm::ServiceName service;
+            os::WaitableHolderType *session;
+        };
+
+        constinit WaitListEntry g_entries[DeferredSessionCountMax];
+        constinit WaitListEntry *g_processing_entry = nullptr;
+        constinit ServiceName g_triggered_service = InvalidServiceName;
+
+        WaitListEntry *Find(ServiceName service) {
+            for (auto &entry : g_entries) {
+                if (entry.service == service) {
+                    return std::addressof(entry);
+                }
+            }
+
+            return nullptr;
+        }
+
+    }
+
+    Result StartRegisterRetry(ServiceName service) {
+        /* Check that we're not already processing a retry. */
+        AMS_ABORT_UNLESS(g_processing_entry == nullptr);
+
+        /* Find a free entry. */
+        auto *entry = Find(InvalidServiceName);
+        R_UNLESS(entry != nullptr, sm::ResultOutOfProcesses());
+
+        /* Initialize the entry. */
+        entry->service = service;
+        entry->session = nullptr;
+
+        /* Set the processing entry. */
+        g_processing_entry = entry;
+
+        return sf::ResultRequestDeferredByUser();
+    }
+
+    void ProcessRegisterRetry(os::WaitableHolderType *session_holder) {
+        /* Verify that we have a processing entry. */
+        AMS_ABORT_UNLESS(g_processing_entry != nullptr);
+
+        /* Process the session. */
+        g_processing_entry->session = session_holder;
+        g_processing_entry = nullptr;
+    }
+
+    void TriggerResume(ServiceName service) {
+        /* Check that we haven't already triggered a resume. */
+        AMS_ABORT_UNLESS(g_triggered_service == InvalidServiceName);
+
+        /* Set the triggered resume. */
+        g_triggered_service = service;
+    }
+
+    void TestAndResume(ResumeFunction resume_function) {
+        /* If we don't have a triggered service, there's nothing to do. */
+        if (g_triggered_service == InvalidServiceName) {
+            return;
+        }
+
+        /* Process all entries. */
+        for (auto &entry : g_entries) {
+            if (entry.service == g_triggered_service) {
+                /* Get the entry's session. */
+                auto * const session = entry.session;
+
+                /* Clear the entry. */
+                entry.service = InvalidServiceName;
+                entry.session = nullptr;
+
+                /* Resume the request. */
+                R_TRY_CATCH(resume_function(session)) {
+                    R_CATCH(sf::ResultRequestDeferred) {
+                        ProcessRegisterRetry(session);
+                    }
+                } R_END_TRY_CATCH_WITH_ABORT_UNLESS;
+            }
+        }
+    }
+
+}

--- a/stratosphere/sm/source/impl/sm_wait_list.hpp
+++ b/stratosphere/sm/source/impl/sm_wait_list.hpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2018-2020 Atmosphère-NX
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+#include <stratosphere.hpp>
+
+namespace ams::sm::impl {
+
+    using ResumeFunction = Result (*)(os::WaitableHolderType *session_holder);
+
+    Result StartRegisterRetry(ServiceName service);
+    void   ProcessRegisterRetry(os::WaitableHolderType *session_holder);
+
+    void TriggerResume(ServiceName service);
+    void TestAndResume(ResumeFunction resume_function);
+
+}

--- a/stratosphere/sm/source/sm_main.cpp
+++ b/stratosphere/sm/source/sm_main.cpp
@@ -111,6 +111,7 @@ int main(int argc, char **argv)
         Handle smm_h;
         R_ABORT_UNLESS(sm::impl::RegisterServiceForSelf(&smm_h, sm::ServiceName::Encode("sm:m"), 1));
         g_server_manager.RegisterServer<sm::impl::IManagerInterface, sm::ManagerService>(smm_h);
+        sm::impl::TestAndResume(ResumeImpl);
     }
 
     /*===== ATMOSPHERE EXTENSION =====*/
@@ -119,6 +120,7 @@ int main(int argc, char **argv)
         Handle smdmnt_h;
         R_ABORT_UNLESS(sm::impl::RegisterServiceForSelf(&smdmnt_h, sm::ServiceName::Encode("sm:dmnt"), 1));
         g_server_manager.RegisterServer<sm::impl::IDebugMonitorInterface, sm::DebugMonitorService>(smdmnt_h);
+        sm::impl::TestAndResume(ResumeImpl);
     }
 
     /*================================*/


### PR DESCRIPTION
This implements accurate-to-nn request deferral (plus atmosphere mitm extensions).

This substantially decreases the amount of redundant request processing required, and additionally allows for actually logging sm service calls via mesosphere without being drowned in deferred fsp-srv requests for the whole boot process.