### PR TITLE
Fix PRODINFO blanking for newer versions.

### DIFF
--- a/stratosphere/ams_mitm/source/amsmitm_prodinfo_utils.cpp
+++ b/stratosphere/ams_mitm/source/amsmitm_prodinfo_utils.cpp
@@ -222,8 +222,6 @@ namespace ams::mitm {
             Blank(info.GetBlock<EcqvEcdsaAmiiboRootCertificateBlock>());
             Blank(info.GetBlock<EcqvBlsAmiiboRootCertificateBlock>());
             Blank(info.GetBlock<ExtendedSslKeyBlock>());
-            if (IsValid(info.GetBlock<Rsa2048DeviceKeyBlock>()) && !IsBlank(info.GetBlock<Rsa2048DeviceKeyBlock>())) Blank(info.GetBlock<Rsa2048DeviceKeyBlock>());
-            if (IsValid(info.GetBlock<Rsa2048DeviceCertificateBlock>()) && !IsBlank(info.GetBlock<Rsa2048DeviceCertificateBlock>())) Blank(info.GetBlock<Rsa2048DeviceCertificateBlock>());
 
             /* Set header hash. */
             crypto::GenerateSha256Hash(std::addressof(info.header.body_hash), sizeof(info.header.body_hash), std::addressof(info.body), sizeof(info.body));


### PR DESCRIPTION
Following a discussion on Discord.

Original message:

My guess is that HOS is now checking Rsa2048DeviceCertificate and/or Rsa2048DeviceKey at boot time. Just like EccB233DeviceCertificate and ExtendedEccB233DeviceKey, a valid CRC is not enough i.e. the console's device id must match those of EccB233DeviceCertificate + 0xC6 and of the decrypted ExtendedEccB233DeviceKey. A simple solution would be to remove line 225 and 226 (https://github.com/Atmosphere-NX/Atmosphere/blob/c547c7f0e7a5de4292b58882f261be11b288ac0e/stratosphere/ams_mitm/source/amsmitm_prodinfo_utils.cpp#L225).
It should not affect the blanking capabilities as EccB233DeviceCertificate was not blanked in the first place (because you cannot simply zero it). Blanking the SSL cert is the important stuff here.
Incognito's implementation was probably created using the "blank as much stuff until it cannot boot anymore" strategy.