### PR TITLE
sm: make sure handles don't get clobbered on failure

### DIFF
--- a/stratosphere/sm/source/impl/sm_service_manager.cpp
+++ b/stratosphere/sm/source/impl/sm_service_manager.cpp
@@ -407,9 +407,15 @@ namespace ams::sm::impl {
             ServiceInfo *free_service = GetFreeServiceInfo();
             R_UNLESS(free_service != nullptr, sm::ResultOutOfServices());
 
+            /* Make sure we keep the handles clean */
+            auto handle_guard = SCOPE_GUARD { *out = INVALID_HANDLE; *(free_service->port_h.GetPointer()) = INVALID_HANDLE; };
+
             /* Create the new service. */
             *out = INVALID_HANDLE;
             R_TRY(svcCreatePort(out, free_service->port_h.GetPointerAndClear(), max_sessions, is_light, free_service->name.name));
+
+            /* We succeeded! */
+            handle_guard.Cancel();
 
             /* Save info. */
             free_service->name = service;


### PR DESCRIPTION
When the system runs out of ports, the CreatePort SVC returns garbage in W1 and W2, 
which are then written into the free service info slot. On subsequent calls to RegisterService, 
SM tries to close these broken handles, which of course fails, making it abort. 
This solves the issue by making sure the handles are cleared in case of failure.