### PR TITLE
set.mitm: fake compatibility for usb!usb30_force_enabled on 9.0.0+

### DIFF
--- a/config_templates/system_settings.ini
+++ b/config_templates/system_settings.ini
@@ -3,6 +3,7 @@
 ; upload_enabled = u8!0x0
 [usb]
 ; Enable USB 3.0 superspeed for homebrew
+; 0 = USB 3.0 support is system default (usually disabled), 1 = USB 3.0 support is enabled.
 ; usb30_force_enabled = u8!0x0
 [ro]
 ; Control whether RO should ease its validation of NROs.

--- a/config_templates/system_settings.ini
+++ b/config_templates/system_settings.ini
@@ -1,9 +1,12 @@
-; Disable uploading error reports to Nintendo
 [eupld]
+; Disable uploading error reports to Nintendo
 ; upload_enabled = u8!0x0
+[usb]
+; Enable USB 3.0 superspeed for homebrew
+; usb30_force_enabled = u8!0x0
+[ro]
 ; Control whether RO should ease its validation of NROs.
 ; (note: this is normally not necessary, and ips patches can be used.)
-[ro]
 ; ease_nro_restriction = u8!0x1
 ; Atmosphere custom settings
 [atmosphere]

--- a/exosphere/program/source/smc/secmon_smc_info.cpp
+++ b/exosphere/program/source/smc/secmon_smc_info.cpp
@@ -286,6 +286,10 @@ namespace ams::secmon::smc {
                     /* Get the log configuration. */
                     args.r[1] = (static_cast<u64>(static_cast<u8>(secmon::GetLogPort())) << 32) | static_cast<u64>(secmon::GetLogBaudRate());
                     break;
+                case ConfigItem::ExosphereForceEnableUsb30:
+                    /* Get whether usb 3.0 should be force-enabled. */
+                    args.r[1] = GetSecmonConfiguration().IsUsb30ForceEnabled();
+                    break;
                 default:
                     return SmcResult::InvalidArgument;
             }

--- a/exosphere/program/source/smc/secmon_smc_info.hpp
+++ b/exosphere/program/source/smc/secmon_smc_info.hpp
@@ -50,6 +50,7 @@ namespace ams::secmon::smc {
         ExosphereEmummcType       = 65007,
         ExospherePayloadAddress   = 65008,
         ExosphereLogConfiguration = 65009,
+        ExosphereForceEnableUsb30 = 65010,
     };
 
     SmcResult SmcGetConfigUser(SmcArguments &args);

--- a/fusee/fusee-secondary/src/exocfg.h
+++ b/fusee/fusee-secondary/src/exocfg.h
@@ -33,6 +33,7 @@
 #define EXOSPHERE_FLAG_ENABLE_USERMODE_PMU_ACCESS           (1 << 4u)
 #define EXOSPHERE_FLAG_BLANK_PRODINFO                       (1 << 5u)
 #define EXOSPHERE_FLAG_ALLOW_WRITING_TO_CAL_SYSMMC          (1 << 6u)
+#define EXOSPHERE_FLAG_FORCE_ENABLE_USB_30                  (1 << 7u)
 
 #define EXOSPHERE_LOG_FLAG_INVERTED (1 << 0u)
 

--- a/libraries/libexosphere/include/exosphere/secmon/secmon_monitor_context.hpp
+++ b/libraries/libexosphere/include/exosphere/secmon/secmon_monitor_context.hpp
@@ -29,6 +29,7 @@ namespace ams::secmon {
         SecureMonitorConfigurationFlag_EnableUserModePerformanceCounterAccess = (1u << 4),
         SecureMonitorConfigurationFlag_ShouldUseBlankCalibrationBinary        = (1u << 5),
         SecureMonitorConfigurationFlag_AllowWritingToCalibrationBinarySysmmc  = (1u << 6),
+        SecureMonitorConfigurationFlag_ForceEnableUsb30                       = (1u << 7),
 
         SecureMonitorConfigurationFlag_Default = SecureMonitorConfigurationFlag_IsDevelopmentFunctionEnabledForKernel,
     };
@@ -101,6 +102,7 @@ namespace ams::secmon {
         constexpr bool EnableUserModePerformanceCounterAccess() const { return (this->flags[0] & SecureMonitorConfigurationFlag_EnableUserModePerformanceCounterAccess) != 0; }
         constexpr bool ShouldUseBlankCalibrationBinary()        const { return (this->flags[0] & SecureMonitorConfigurationFlag_ShouldUseBlankCalibrationBinary)        != 0; }
         constexpr bool AllowWritingToCalibrationBinarySysmmc()  const { return (this->flags[0] & SecureMonitorConfigurationFlag_AllowWritingToCalibrationBinarySysmmc)  != 0; }
+        constexpr bool IsUsb30ForceEnabled()                    const { return (this->flags[0] & SecureMonitorConfigurationFlag_ForceEnableUsb30)                       != 0; }
 
         constexpr bool IsDevelopmentFunctionEnabled(bool for_kern) const { return for_kern ? this->IsDevelopmentFunctionEnabledForKernel() : this->IsDevelopmentFunctionEnabledForUser(); }
     };

--- a/libraries/libstratosphere/include/stratosphere/spl/spl_api.hpp
+++ b/libraries/libstratosphere/include/stratosphere/spl/spl_api.hpp
@@ -78,6 +78,10 @@ namespace ams::spl {
         return ::ams::spl::GetConfigBool(::ams::spl::ConfigItem::DisableProgramVerification);
     }
 
+    inline bool IsUsb30ForceEnabled() {
+        return ::ams::spl::GetConfigBool(::ams::spl::ConfigItem::ExosphereForceEnableUsb30);
+    }
+
     Result SetBootReason(BootReasonValue boot_reason);
     Result GetBootReason(BootReasonValue *out);
 

--- a/libraries/libstratosphere/include/stratosphere/spl/spl_types.hpp
+++ b/libraries/libstratosphere/include/stratosphere/spl/spl_types.hpp
@@ -223,26 +223,30 @@ namespace ams::spl {
         Package2Hash                  = 17,
 
         /* Extension config items for exosphere. */
-        ExosphereApiVersion     = 65000,
-        ExosphereNeedsReboot    = 65001,
-        ExosphereNeedsShutdown  = 65002,
-        ExosphereGitCommitHash  = 65003,
-        ExosphereHasRcmBugPatch = 65004,
-        ExosphereBlankProdInfo  = 65005,
-        ExosphereAllowCalWrites = 65006,
-        ExosphereEmummcType     = 65007,
-        ExospherePayloadAddress = 65008,
+        ExosphereApiVersion       = 65000,
+        ExosphereNeedsReboot      = 65001,
+        ExosphereNeedsShutdown    = 65002,
+        ExosphereGitCommitHash    = 65003,
+        ExosphereHasRcmBugPatch   = 65004,
+        ExosphereBlankProdInfo    = 65005,
+        ExosphereAllowCalWrites   = 65006,
+        ExosphereEmummcType       = 65007,
+        ExospherePayloadAddress   = 65008,
+        ExosphereLogConfiguration = 65009,
+        ExosphereForceEnableUsb30 = 65010,
     };
 
 }
 
 /* Extensions to libnx spl config item enum. */
-constexpr inline SplConfigItem SplConfigItem_ExosphereApiVersion     = static_cast<SplConfigItem>(65000);
-constexpr inline SplConfigItem SplConfigItem_ExosphereNeedsReboot    = static_cast<SplConfigItem>(65001);
-constexpr inline SplConfigItem SplConfigItem_ExosphereNeedsShutdown  = static_cast<SplConfigItem>(65002);
-constexpr inline SplConfigItem SplConfigItem_ExosphereGitCommitHash  = static_cast<SplConfigItem>(65003);
-constexpr inline SplConfigItem SplConfigItem_ExosphereHasRcmBugPatch = static_cast<SplConfigItem>(65004);
-constexpr inline SplConfigItem SplConfigItem_ExosphereBlankProdInfo  = static_cast<SplConfigItem>(65005);
-constexpr inline SplConfigItem SplConfigItem_ExosphereAllowCalWrites = static_cast<SplConfigItem>(65006);
-constexpr inline SplConfigItem SplConfigItem_ExosphereEmummcType     = static_cast<SplConfigItem>(65007);
-constexpr inline SplConfigItem SplConfigItem_ExospherePayloadAddress = static_cast<SplConfigItem>(65008);
+constexpr inline SplConfigItem SplConfigItem_ExosphereApiVersion       = static_cast<SplConfigItem>(65000);
+constexpr inline SplConfigItem SplConfigItem_ExosphereNeedsReboot      = static_cast<SplConfigItem>(65001);
+constexpr inline SplConfigItem SplConfigItem_ExosphereNeedsShutdown    = static_cast<SplConfigItem>(65002);
+constexpr inline SplConfigItem SplConfigItem_ExosphereGitCommitHash    = static_cast<SplConfigItem>(65003);
+constexpr inline SplConfigItem SplConfigItem_ExosphereHasRcmBugPatch   = static_cast<SplConfigItem>(65004);
+constexpr inline SplConfigItem SplConfigItem_ExosphereBlankProdInfo    = static_cast<SplConfigItem>(65005);
+constexpr inline SplConfigItem SplConfigItem_ExosphereAllowCalWrites   = static_cast<SplConfigItem>(65006);
+constexpr inline SplConfigItem SplConfigItem_ExosphereEmummcType       = static_cast<SplConfigItem>(65007);
+constexpr inline SplConfigItem SplConfigItem_ExospherePayloadAddress   = static_cast<SplConfigItem>(65008);
+constexpr inline SplConfigItem SplConfigItem_ExosphereLogConfiguration = static_cast<SplConfigItem>(65009);
+constexpr inline SplConfigItem SplConfigItem_ExosphereForceEnableUsb30 = static_cast<SplConfigItem>(65010);

--- a/libraries/libstratosphere/source/boot2/boot2_api.cpp
+++ b/libraries/libstratosphere/source/boot2/boot2_api.cpp
@@ -307,6 +307,10 @@ namespace ams::boot2 {
             });
         }
 
+        bool IsUsbRequiredToMountSdCard() {
+            return hos::GetVersion() >= hos::Version_9_0_0;
+        }
+
     }
 
     /* Boot2 API. */
@@ -347,8 +351,10 @@ namespace ams::boot2 {
             /* Launch pcv. */
             LaunchProgram(nullptr, ncm::ProgramLocation::Make(ncm::SystemProgramId::Pcv, ncm::StorageId::BuiltInSystem), 0);
 
-            /* Launch usb. */
-            LaunchProgram(nullptr, ncm::ProgramLocation::Make(ncm::SystemProgramId::Usb, ncm::StorageId::BuiltInSystem), 0);
+            /* On 9.0.0+, FS depends on the USB sysmodule having been launched in order to mount the SD card. */
+            if (IsUsbRequiredToMountSdCard()) {
+                LaunchProgram(nullptr, ncm::ProgramLocation::Make(ncm::SystemProgramId::Usb, ncm::StorageId::BuiltInSystem), 0);
+            }
         }
 
         /* Wait for the SD card required services to be ready. */
@@ -370,6 +376,11 @@ namespace ams::boot2 {
 
     void LaunchPostSdCardBootPrograms() {
         /* This code is normally run by boot2. */
+
+        /* Launch the usb system module, if we haven't already. */
+        if (!IsUsbRequiredToMountSdCard()) {
+            LaunchProgram(nullptr, ncm::ProgramLocation::Make(ncm::SystemProgramId::Usb, ncm::StorageId::BuiltInSystem), 0);
+        }
 
         /* Find out whether we are maintenance mode. */
         const bool maintenance = IsMaintenanceMode();

--- a/stratosphere/ams_mitm/source/set_mitm/settings_sd_kvs.cpp
+++ b/stratosphere/ams_mitm/source/set_mitm/settings_sd_kvs.cpp
@@ -310,6 +310,9 @@ namespace ams::settings::fwdbg {
             /* Disable uploading error reports to Nintendo. */
             R_ABORT_UNLESS(ParseSettingsItemValue("eupld", "upload_enabled", "u8!0x0"));
 
+            /* Enable USB 3.0 superspeed for homebrew */
+            R_ABORT_UNLESS(ParseSettingsItemValue("usb", "usb30_force_enabled", spl::IsUsb30ForceEnabled() ? "u8!0x1" : "u8!0x0"));
+
             /* Control whether RO should ease its validation of NROs. */
             /* (note: this is normally not necessary, and ips patches can be used.) */
             R_ABORT_UNLESS(ParseSettingsItemValue("ro", "ease_nro_restriction", "u8!0x1"));

--- a/stratosphere/loader/source/ldr_embedded_usb_patches.inc
+++ b/stratosphere/loader/source/ldr_embedded_usb_patches.inc
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018-2021 Atmosphère-NX
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* Patch fallback case to mov w0, #1 rather than retrieving settings flag. */
+constexpr inline const EmbeddedPatchEntry Usb30ForceEnablePatches_9_0_0[] = {
+    { 0x521C, "\x20\x00\x80\x52", 4 },
+};
+
+/* Patch fallback case to mov w0, #1 rather than retrieving settings flag. */
+constexpr inline const EmbeddedPatchEntry Usb30ForceEnablePatches_10_0_0[] = {
+    { 0x5494, "\x20\x00\x80\x52", 4 },
+};
+
+/* Patch getter functions to return 1. */
+constexpr inline const EmbeddedPatchEntry Usb30ForceEnablePatches_11_0_0[] = {
+    { 0x85DC, "\x20\x00\x80\x52\xC0\x03\x5F\xD6", 8 },
+    { 0x866C, "\x20\x00\x80\x52\xC0\x03\x5F\xD6", 8 },
+};
+
+constexpr inline const EmbeddedPatch Usb30ForceEnablePatches[] = {
+    { ParseModuleId("C0D3F4E87E8B0FE9BBE9F1968A20767F3DC08E03"), util::size(Usb30ForceEnablePatches_9_0_0),  Usb30ForceEnablePatches_9_0_0 },
+    { ParseModuleId("B9C700CA8335F8BAA0D2041D8D09F772890BA988"), util::size(Usb30ForceEnablePatches_10_0_0), Usb30ForceEnablePatches_10_0_0 },
+    { ParseModuleId("95BAF06A69650C215A5DD50CF8BD2A603E7AD3C2"), util::size(Usb30ForceEnablePatches_11_0_0), Usb30ForceEnablePatches_11_0_0 },
+};

--- a/stratosphere/loader/source/ldr_patcher.hpp
+++ b/stratosphere/loader/source/ldr_patcher.hpp
@@ -21,4 +21,7 @@ namespace ams::ldr {
     /* Apply IPS patches. */
     void LocateAndApplyIpsPatchesToModule(const u8 *build_id, uintptr_t mapped_nso, size_t mapped_size);
 
+    /* Apply embedded patches. */
+    void ApplyEmbeddedPatchesToModule(const u8 *build_id, uintptr_t mapped_nso, size_t mapped_size);
+
 }

--- a/stratosphere/loader/source/ldr_process_creation.cpp
+++ b/stratosphere/loader/source/ldr_process_creation.cpp
@@ -536,6 +536,9 @@ namespace ams::ldr {
 
                 /* Apply IPS patches. */
                 LocateAndApplyIpsPatchesToModule(nso_header->build_id, map_address, nso_size);
+
+                /* Apply embedded patches. */
+                ApplyEmbeddedPatchesToModule(nso_header->build_id, map_address, nso_size);
             }
 
             /* Set permissions. */

--- a/stratosphere/loader/source/ldr_process_creation.cpp
+++ b/stratosphere/loader/source/ldr_process_creation.cpp
@@ -534,11 +534,11 @@ namespace ams::ldr {
                 std::memset(reinterpret_cast<void *>(map_address + ro_end),   0, nso_header->rw_dst_offset - ro_end);
                 std::memset(reinterpret_cast<void *>(map_address + rw_end), 0, nso_header->bss_size);
 
-                /* Apply IPS patches. */
-                LocateAndApplyIpsPatchesToModule(nso_header->build_id, map_address, nso_size);
-
                 /* Apply embedded patches. */
                 ApplyEmbeddedPatchesToModule(nso_header->build_id, map_address, nso_size);
+
+                /* Apply IPS patches. */
+                LocateAndApplyIpsPatchesToModule(nso_header->build_id, map_address, nso_size);
             }
 
             /* Set permissions. */


### PR DESCRIPTION
This adds support for usb3.0 enable via system_settings.ini on 9.0.0+.

To work around the "usb is launched before the sd card is available" problem, we parse system_settings.ini in fusee, and pass the flag down to userland via exosphere.

We then embed usb sysmodule patches to make the module read the setting as true, when this flag is set.

Note that we only embed patches for 9.0.0+, since on older versions we can just affect the setting.