### PR TITLE
Assume gcc 11

### DIFF
--- a/libraries/libstratosphere/include/stratosphere/dd/dd_types.hpp
+++ b/libraries/libstratosphere/include/stratosphere/dd/dd_types.hpp
@@ -20,14 +20,7 @@ namespace ams::dd {
 
     using ProcessHandle = ::Handle;
 
-    /* TODO gcc-11: using MemoryPermission = os::MemoryPermission; using enum os::MemoryPermission; */
-
-    enum MemoryPermission {
-        MemoryPermission_None      = 0,
-        MemoryPermission_ReadOnly  = (1u << 0),
-        MemoryPermission_WriteOnly = (1u << 1),
-
-        MemoryPermission_ReadWrite = MemoryPermission_ReadOnly | MemoryPermission_WriteOnly,
-    };
+    using MemoryPermission = os::MemoryPermission;
+    using enum os::MemoryPermission;
 
 }

--- a/libraries/libstratosphere/include/stratosphere/tipc/tipc_server_manager.hpp
+++ b/libraries/libstratosphere/include/stratosphere/tipc/tipc_server_manager.hpp
@@ -54,24 +54,30 @@ namespace ams::tipc {
             static constexpr inline bool IsDeferralSupported = !std::same_as<DeferralManagerType, DummyDeferralManager>;
             using ResumeKey = typename DeferralManagerType::Key;
 
-            static ALWAYS_INLINE uintptr_t ConvertKeyToMessage(ResumeKey key) {
+            static constexpr ALWAYS_INLINE uintptr_t ConvertKeyToMessage(ResumeKey key) {
                 static_assert(sizeof(key) <= sizeof(uintptr_t));
                 static_assert(std::is_trivial<ResumeKey>::value);
 
-                /* TODO: std::bit_cast */
-                uintptr_t converted = 0;
-                std::memcpy(std::addressof(converted), std::addressof(key), sizeof(key));
-                return converted;
+                if constexpr (sizeof(key) == sizeof(uintptr_t)) {
+                    return std::bit_cast<uintptr_t>(key);
+                } else {
+                    uintptr_t converted = 0;
+                    std::memcpy(std::addressof(converted), std::addressof(key), sizeof(key));
+                    return converted;
+                }
             }
 
-            static ALWAYS_INLINE ResumeKey ConvertMessageToKey(uintptr_t message) {
+            static constexpr ALWAYS_INLINE ResumeKey ConvertMessageToKey(uintptr_t message) {
                 static_assert(sizeof(ResumeKey) <= sizeof(uintptr_t));
                 static_assert(std::is_trivial<ResumeKey>::value);
 
-                /* TODO: std::bit_cast */
-                ResumeKey converted = {};
-                std::memcpy(std::addressof(converted), std::addressof(message), sizeof(converted));
-                return converted;
+                if constexpr (sizeof(ResumeKey) == sizeof(uintptr_t)) {
+                    return std::bit_cast<ResumeKey>(message);
+                } else {
+                    ResumeKey converted = {};
+                    std::memcpy(std::addressof(converted), std::addressof(message), sizeof(converted));
+                    return converted;
+                }
             }
 
             template<size_t Ix> requires (Ix < NumPorts)

--- a/libraries/libstratosphere/source/ncm/ncm_content_meta_database_impl.cpp
+++ b/libraries/libstratosphere/source/ncm/ncm_content_meta_database_impl.cpp
@@ -308,7 +308,7 @@ namespace ams::ncm {
             out_orphaned[i] = true;
         }
 
-        auto IsOrphanedContent = [](const sf::InArray<ContentId> &list, const ncm::ContentId &id) ALWAYS_INLINE_LAMBDA {
+        auto IsOrphanedContent = [] ALWAYS_INLINE_LAMBDA (const sf::InArray<ContentId> &list, const ncm::ContentId &id) -> std::optional<size_t> {
             /* Check if any input content ids match our found content id. */
             for (size_t i = 0; i < list.GetSize(); i++) {
                 if (list[i] == id) {
@@ -316,9 +316,7 @@ namespace ams::ncm {
                 }
             }
 
-            /* TODO: C++20 (gcc 10) fixes ALWAYS_INLINE_LAMBDA in conjunction with trailing return types. */
-            /* This should be changed to std::nullopt once possible. */
-            return std::optional<size_t>(std::nullopt);
+            return std::nullopt;
         };
 
         /* Iterate over all entries. */

--- a/libraries/libvapours/include/vapours/util/util_bitutil.hpp
+++ b/libraries/libvapours/include/vapours/util/util_bitutil.hpp
@@ -133,7 +133,6 @@ namespace ams::util {
 
     template<typename T> requires std::integral<T>
     constexpr ALWAYS_INLINE int PopCount(T x) {
-        /* TODO: C++20 std::bit_cast */
         using U = typename std::make_unsigned<T>::type;
         U u = static_cast<U>(x);
 
@@ -174,7 +173,6 @@ namespace ams::util {
             }
             return PopCount(static_cast<T>(~x));
         } else {
-            /* TODO: C++20 std::bit_cast */
             using U = typename std::make_unsigned<T>::type;
             const U u = static_cast<U>(x);
             if constexpr (std::is_same<U, unsigned long long>::value) {


### PR DESCRIPTION
With gcc 11, we can use stuff like std::bit_cast and using enum, both of which are pretty nice.

However, we shouldn't commit gcc 11 assumption to master until a gcc 11 devkitA64 release occurs.

This branch should be merged when that happens, but not before.

In the meantime, all commits which use newer gcc features should go here.