### PR TITLE
Reduce insert_splash_screen processing time from ~1m20s to ~0.6s

### DIFF
--- a/utilities/insert_splash_screen.py
+++ b/utilities/insert_splash_screen.py
@@ -16,7 +16,7 @@ def convert_image(image_fn):
     assert w == 720
     assert h == 1280
     splash = splash.convert('RGBA')
-    splash_bin = b''
+    splash_bin = bytearray()
     for row in range(SPLASH_SCREEN_WIDTH):
         for col in range(SPLASH_SCREEN_HEIGHT):
             r, g, b, a = splash.getpixel((col, row))


### PR DESCRIPTION
Script to change splash screen was slow.
I change the code to use bytearray() instead of `+=` on a bytes (That is very slow on py3)

Time before modification
```bash
$ time python3 insert_splash_screen.py splash.png package3 

real	1m23,592s
user	0m58,354s
sys	0m25,081s
```

```bash
$ time python2 insert_splash_screen.py splash.png package3 

real	0m0,600s
user	0m0,571s
sys	0m0,014s
```

Time taken after the modification
```bash
$ time python3 insert_splash_screen.py splash.png package3 

real	0m0,606s
user	0m0,579s
sys	0m0,017s
```
```bash
$ time python2 insert_splash_screen.py splash.png package3 

real	0m0,598s
user	0m0,568s
sys	0m0,020s
```


So time reduce from `1m23s` to `0.6s` on my computer.