### PR TITLE
ams: Allow standalone gdbstub while starlink is in development.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,7 @@ dist-no-debug: all
 	mkdir -p atmosphere-$(AMSVER)/stratosphere_romfs/atmosphere/contents/0100000000000042
 	mkdir -p atmosphere-$(AMSVER)/stratosphere_romfs/atmosphere/contents/0100000000000420
 	mkdir -p atmosphere-$(AMSVER)/stratosphere_romfs/atmosphere/contents/010000000000B240
+	mkdir -p atmosphere-$(AMSVER)/stratosphere_romfs/atmosphere/contents/010000000000D609
 	mkdir -p atmosphere-$(AMSVER)/stratosphere_romfs/atmosphere/contents/010000000000D623
 	cp stratosphere/boot2/boot2.nsp atmosphere-$(AMSVER)/stratosphere_romfs/atmosphere/contents/0100000000000008/exefs.nsp
 	cp stratosphere/dmnt/dmnt.nsp atmosphere-$(AMSVER)/stratosphere_romfs/atmosphere/contents/010000000000000D/exefs.nsp
@@ -125,6 +126,7 @@ dist-no-debug: all
 	cp stratosphere/pgl/pgl.nsp atmosphere-$(AMSVER)/stratosphere_romfs/atmosphere/contents/0100000000000042/exefs.nsp
 	cp stratosphere/LogManager/LogManager.nsp atmosphere-$(AMSVER)/stratosphere_romfs/atmosphere/contents/0100000000000420/exefs.nsp
 	cp stratosphere/htc/htc.nsp atmosphere-$(AMSVER)/stratosphere_romfs/atmosphere/contents/010000000000B240/exefs.nsp
+	cp stratosphere/dmnt.gen2/dmnt.gen2.nsp atmosphere-$(AMSVER)/stratosphere_romfs/atmosphere/contents/010000000000D609/exefs.nsp
 	cp stratosphere/TioServer/TioServer.nsp atmosphere-$(AMSVER)/stratosphere_romfs/atmosphere/contents/010000000000D623/exefs.nsp
 	@build_romfs atmosphere-$(AMSVER)/stratosphere_romfs atmosphere-$(AMSVER)/atmosphere/stratosphere.romfs
 	rm -r atmosphere-$(AMSVER)/stratosphere_romfs

--- a/libraries/libmesosphere/include/mesosphere/kern_build_config.hpp
+++ b/libraries/libmesosphere/include/mesosphere/kern_build_config.hpp
@@ -40,6 +40,12 @@
 /* of the right side, and so this does not actually cost any space. */
 #define MESOSPHERE_ENABLE_DEVIRTUALIZED_DYNAMIC_CAST
 
+/* NOTE: This enables usage of KDebug handles as parameter for svc::GetInfo */
+/* calls which require a process parameter. This enables a debugger to obtain */
+/* address space/layout information, for example. However, it changes abi, and so */
+/* this define allows toggling the extension. */
+#define MESOSPHERE_ENABLE_GET_INFO_OF_DEBUG_PROCESS
+
 /* NOTE: This uses currently-reserved bits inside the MapRange capability */
 /* in order to support large physical addresses (40-bit instead of 36). */
 /* This is toggleable in order to disable it if N ever uses those bits. */

--- a/libraries/libmesosphere/source/kern_k_memory_block_manager.cpp
+++ b/libraries/libmesosphere/source/kern_k_memory_block_manager.cpp
@@ -19,7 +19,7 @@ namespace ams::kern {
 
     namespace {
 
-        constexpr std::tuple<KMemoryState, const char *> MemoryStateNames[] = {
+        constexpr const std::pair<KMemoryState, const char *> MemoryStateNames[] = {
             {KMemoryState_Free               , "----- Free -----"},
             {KMemoryState_Io                 , "Io              "},
             {KMemoryState_Static             , "Static          "},
@@ -41,6 +41,7 @@ namespace ams::kern {
             {KMemoryState_Kernel             , "Kernel          "},
             {KMemoryState_GeneratedCode      , "GeneratedCode   "},
             {KMemoryState_CodeOut            , "CodeOut         "},
+            {KMemoryState_Coverage           , "Coverage        "},
         };
 
         constexpr const char *GetMemoryStateName(KMemoryState state) {

--- a/libraries/libstratosphere/include/stratosphere/fssystem/fssystem_utility.hpp
+++ b/libraries/libstratosphere/include/stratosphere/fssystem/fssystem_utility.hpp
@@ -118,12 +118,12 @@ namespace ams::fssystem {
 
     /* Copy API. */
     Result CopyFile(fs::fsa::IFileSystem *dst_fs, fs::fsa::IFileSystem *src_fs, const char *dst_parent_path, const char *src_path, const fs::DirectoryEntry *dir_ent, void *work_buf, size_t work_buf_size);
-    NX_INLINE Result CopyFile(fs::fsa::IFileSystem *fs, const char *dst_parent_path, const char *src_path, const fs::DirectoryEntry *dir_ent, void *work_buf, size_t work_buf_size) {
+    ALWAYS_INLINE Result CopyFile(fs::fsa::IFileSystem *fs, const char *dst_parent_path, const char *src_path, const fs::DirectoryEntry *dir_ent, void *work_buf, size_t work_buf_size) {
         return CopyFile(fs, fs, dst_parent_path, src_path, dir_ent, work_buf, work_buf_size);
     }
 
     Result CopyDirectoryRecursively(fs::fsa::IFileSystem *dst_fs, fs::fsa::IFileSystem *src_fs, const char *dst_path, const char *src_path, void *work_buf, size_t work_buf_size);
-    NX_INLINE Result CopyDirectoryRecursively(fs::fsa::IFileSystem *fs, const char *dst_path, const char *src_path, void *work_buf, size_t work_buf_size) {
+    ALWAYS_INLINE Result CopyDirectoryRecursively(fs::fsa::IFileSystem *fs, const char *dst_path, const char *src_path, void *work_buf, size_t work_buf_size) {
         return CopyDirectoryRecursively(fs, fs, dst_path, src_path, work_buf, work_buf_size);
     }
 
@@ -148,11 +148,11 @@ namespace ams::fssystem {
     Result EnsureDirectoryRecursively(fs::fsa::IFileSystem *fs, const char *path);
     Result EnsureParentDirectoryRecursively(fs::fsa::IFileSystem *fs, const char *path);
 
-    template<typename F>
-    NX_INLINE Result RetryFinitelyForTargetLocked(F f) {
+    template<s64 RetryMilliSeconds = 100>
+    ALWAYS_INLINE Result RetryFinitelyForTargetLocked(auto f) {
         /* Retry up to 10 times, 100ms between retries. */
         constexpr s32 MaxRetryCount = 10;
-        constexpr TimeSpan RetryWaitTime = TimeSpan::FromMilliSeconds(100);
+        constexpr TimeSpan RetryWaitTime = TimeSpan::FromMilliSeconds(RetryMilliSeconds);
 
         s32 remaining_retries = MaxRetryCount;
         while (true) {

--- a/libraries/libstratosphere/include/stratosphere/socket/socket_api.hpp
+++ b/libraries/libstratosphere/include/stratosphere/socket/socket_api.hpp
@@ -43,6 +43,7 @@ namespace ams::socket {
 
     s32 Shutdown(s32 desc, ShutdownMethod how);
 
+    s32 Socket(Family domain, Type type, Protocol protocol);
     s32 SocketExempt(Family domain, Type type, Protocol protocol);
 
     s32 Accept(s32 desc, SockAddr *out_address, SockLenT *out_addr_len);

--- a/libraries/libstratosphere/include/stratosphere/socket/socket_system_config.hpp
+++ b/libraries/libstratosphere/include/stratosphere/socket/socket_system_config.hpp
@@ -57,4 +57,42 @@ namespace ams::socket {
             }
     };
 
+    class SystemConfigLightDefault : public Config {
+        public:
+            static constexpr size_t DefaultTcpInitialSendBufferSize     = 16_KB;
+            static constexpr size_t DefaultTcpInitialReceiveBufferSize  = 16_KB;
+            static constexpr size_t DefaultTcpAutoSendBufferSizeMax     = 0_KB;
+            static constexpr size_t DefaultTcpAutoReceiveBufferSizeMax  = 0_KB;
+            static constexpr size_t DefaultUdpSendBufferSize            = 9_KB;
+            static constexpr size_t DefaultUdpReceiveBufferSize         = 42240;
+            static constexpr auto   DefaultSocketBufferEfficiency       = 2;
+            static constexpr auto   DefaultConcurrency                  = 2;
+            static constexpr size_t DefaultAllocatorPoolSize            = 64_KB;
+
+            static constexpr size_t PerTcpSocketWorstCaseMemoryPoolSize = [] {
+                constexpr size_t WorstCaseTcpSendBufferSize    = AlignMss(std::max(DefaultTcpInitialSendBufferSize, DefaultTcpAutoSendBufferSizeMax));
+                constexpr size_t WorstCaseTcpReceiveBufferSize = AlignMss(std::max(DefaultTcpInitialReceiveBufferSize, DefaultTcpAutoReceiveBufferSizeMax));
+
+                return util::AlignUp(WorstCaseTcpSendBufferSize * DefaultSocketBufferEfficiency + WorstCaseTcpReceiveBufferSize * DefaultSocketBufferEfficiency, os::MemoryPageSize);
+            }();
+
+            static constexpr size_t PerUdpSocketWorstCaseMemoryPoolSize = [] {
+                constexpr size_t WorstCaseUdpSendBufferSize    = AlignMss(DefaultUdpSendBufferSize);
+                constexpr size_t WorstCaseUdpReceiveBufferSize = AlignMss(DefaultUdpReceiveBufferSize);
+
+                return util::AlignUp(WorstCaseUdpSendBufferSize * DefaultSocketBufferEfficiency + WorstCaseUdpReceiveBufferSize * DefaultSocketBufferEfficiency, os::MemoryPageSize);
+            }();
+        public:
+            constexpr SystemConfigLightDefault(void *mp, size_t mp_sz, size_t ap, int c=DefaultConcurrency)
+                : Config(mp, mp_sz, ap,
+                         DefaultTcpInitialSendBufferSize, DefaultTcpInitialReceiveBufferSize,
+                         DefaultTcpAutoSendBufferSizeMax, DefaultTcpAutoReceiveBufferSizeMax,
+                         DefaultUdpSendBufferSize, DefaultUdpReceiveBufferSize,
+                         DefaultSocketBufferEfficiency, c)
+            {
+                /* Mark as system. */
+                m_system = true;
+            }
+    };
+
 }

--- a/libraries/libstratosphere/source/boot2/boot2_api.cpp
+++ b/libraries/libstratosphere/source/boot2/boot2_api.cpp
@@ -188,6 +188,12 @@ namespace ams::boot2 {
             return enable_htc != 0;
         }
 
+        bool IsStandaloneGdbstubEnabled() {
+            u8 enable_gdbstub = 0;
+            settings::fwdbg::GetSettingsItemValue(std::addressof(enable_gdbstub), sizeof(enable_gdbstub), "atmosphere", "enable_standalone_gdbstub");
+            return enable_gdbstub != 0;
+        }
+
         bool IsAtmosphereLogManagerEnabled() {
             /* If htc is enabled, ams log manager is enabled. */
             if (IsHtcEnabled()) {
@@ -403,6 +409,9 @@ namespace ams::boot2 {
             LaunchProgram(nullptr, ncm::ProgramLocation::Make(ncm::SystemProgramId::Htc,      ncm::StorageId::None), 0);
             LaunchProgram(nullptr, ncm::ProgramLocation::Make(ncm::SystemProgramId::Cs,       ncm::StorageId::None), 0);
             LaunchProgram(nullptr, ncm::ProgramLocation::Make(ncm::SystemProgramId::DmntGen2, ncm::StorageId::None), 0);
+        } else if (IsStandaloneGdbstubEnabled()) {
+            LaunchProgram(nullptr, ncm::ProgramLocation::Make(ncm::SystemProgramId::DmntGen2, ncm::StorageId::None), 0);
+            LaunchProgram(nullptr, ncm::ProgramLocation::Make(ncm::SystemProgramId::Tma,  ncm::StorageId::BuiltInSystem), 0);
         } else {
             LaunchProgram(nullptr, ncm::ProgramLocation::Make(ncm::SystemProgramId::Dmnt, ncm::StorageId::None), 0);
             LaunchProgram(nullptr, ncm::ProgramLocation::Make(ncm::SystemProgramId::Tma,  ncm::StorageId::BuiltInSystem), 0);

--- a/libraries/libstratosphere/source/osdbg/impl/osdbg_thread_local_region.os.horizon.hpp
+++ b/libraries/libstratosphere/source/osdbg/impl/osdbg_thread_local_region.os.horizon.hpp
@@ -54,7 +54,7 @@ namespace ams::osdbg::impl {
     static_assert(AMS_OFFSETOF(ThreadLocalRegionIlp32, tls) == 0x1C0);
 
     struct LibnxThreadVars {
-        static constexpr u32 Magic = util::FourCC<'!','T','V','$'>::Code;
+        static constexpr u32 Magic = util::ReverseFourCC<'!','T','V','$'>::Code;
 
         u32 magic;
         ::Handle handle;
@@ -69,11 +69,11 @@ namespace ams::osdbg::impl {
         volatile u16 disable_counter;
         volatile u16 interrupt_flag;
         u32 reserved0;
-        u64 tls[(0x1E0 - 0x108) / sizeof(u64)];
+        u64 tls[(0x200 - sizeof(LibnxThreadVars) - 0x108) / sizeof(u64)];
         LibnxThreadVars thread_vars;
     };
     static_assert(sizeof(ThreadLocalRegionLibnx) == sizeof(svc::ThreadLocalRegion));
-    static_assert(AMS_OFFSETOF(ThreadLocalRegionLibnx, thread_vars) == 0x1E0);
+    static_assert(AMS_OFFSETOF(ThreadLocalRegionLibnx, thread_vars) == 0x200 - sizeof(LibnxThreadVars));
 
     struct LibnxThreadEntryArgs {
         u64 t;

--- a/libraries/libstratosphere/source/osdbg/osdbg_thread.cpp
+++ b/libraries/libstratosphere/source/osdbg/osdbg_thread.cpp
@@ -50,9 +50,9 @@ namespace ams::osdbg {
         } else {
             /* Special-case libnx threads. */
             if (thread_info->_thread_type_type == ThreadTypeType_Libnx) {
-                util::TSNPrintf(dst, os::ThreadNameLengthMax, "libnx Thread_0x%p", reinterpret_cast<void *>(thread_info->_thread_type));
+                util::TSNPrintf(dst, os::ThreadNameLengthMax, "libnx Thread_%p", reinterpret_cast<void *>(thread_info->_thread_type));
             } else {
-                util::TSNPrintf(dst, os::ThreadNameLengthMax, "Thread_0x%p", reinterpret_cast<void *>(thread_info->_thread_type));
+                util::TSNPrintf(dst, os::ThreadNameLengthMax, "Thread_%p", reinterpret_cast<void *>(thread_info->_thread_type));
             }
 
             return ResultSuccess();

--- a/libraries/libstratosphere/source/osdbg/osdbg_thread.cpp
+++ b/libraries/libstratosphere/source/osdbg/osdbg_thread.cpp
@@ -50,9 +50,9 @@ namespace ams::osdbg {
         } else {
             /* Special-case libnx threads. */
             if (thread_info->_thread_type_type == ThreadTypeType_Libnx) {
-                util::TSNPrintf(dst, os::ThreadNameLengthMax, "libnx Thread_%p", reinterpret_cast<void *>(thread_info->_thread_type));
+                util::TSNPrintf(dst, os::ThreadNameLengthMax, "libnx Thread_0x%010lx", reinterpret_cast<uintptr_t>(thread_info->_thread_type));
             } else {
-                util::TSNPrintf(dst, os::ThreadNameLengthMax, "Thread_%p", reinterpret_cast<void *>(thread_info->_thread_type));
+                util::TSNPrintf(dst, os::ThreadNameLengthMax, "Thread_0x%010lx", reinterpret_cast<uintptr_t>(thread_info->_thread_type));
             }
 
             return ResultSuccess();

--- a/libraries/libstratosphere/source/socket/impl/socket_api.hpp
+++ b/libraries/libstratosphere/source/socket/impl/socket_api.hpp
@@ -41,6 +41,7 @@ namespace ams::socket::impl {
 
     s32 Shutdown(s32 desc, ShutdownMethod how);
 
+    s32 Socket(Family domain, Type type, Protocol protocol);
     s32 SocketExempt(Family domain, Type type, Protocol protocol);
 
     s32 Accept(s32 desc, SockAddr *out_address, SockLenT *out_addr_len);

--- a/libraries/libstratosphere/source/socket/impl/socket_api.os.horizon.cpp
+++ b/libraries/libstratosphere/source/socket/impl/socket_api.os.horizon.cpp
@@ -206,6 +206,8 @@ namespace ams::socket::impl {
 
             /* TODO: socket::resolver::EnableResolverCalls()? Not necessary in our case (htc), but consider calling it. */
 
+            g_initialized = true;
+
             return ResultSuccess();
         }
 
@@ -413,6 +415,22 @@ namespace ams::socket::impl {
         /* Perform the call. */
         Errno error = Errno::ESuccess;
         int result  = ::bsdShutdown(desc, static_cast<int>(how));
+        TranslateResultToBsdError(error, result);
+
+        if (result < 0) {
+            socket::impl::SetLastError(error);
+        }
+
+        return result;
+    }
+
+    s32 Socket(Family domain, Type type, Protocol protocol) {
+        /* Check pre-conditions. */
+        AMS_ABORT_UNLESS(IsInitialized());
+
+        /* Perform the call. */
+        Errno error = Errno::ESuccess;
+        int result  = ::bsdSocket(static_cast<int>(domain), static_cast<int>(type), static_cast<int>(protocol));
         TranslateResultToBsdError(error, result);
 
         if (result < 0) {

--- a/libraries/libstratosphere/source/socket/socket_api.cpp
+++ b/libraries/libstratosphere/source/socket/socket_api.cpp
@@ -74,6 +74,10 @@ namespace ams::socket {
         return impl::Shutdown(desc, how);
     }
 
+    s32 Socket(Family domain, Type type, Protocol protocol) {
+        return impl::Socket(domain, type, protocol);
+    }
+
     s32 SocketExempt(Family domain, Type type, Protocol protocol) {
         return impl::SocketExempt(domain, type, protocol);
     }

--- a/stratosphere/ams_mitm/source/set_mitm/settings_sd_kvs.cpp
+++ b/stratosphere/ams_mitm/source/set_mitm/settings_sd_kvs.cpp
@@ -378,6 +378,12 @@ namespace ams::settings::fwdbg {
             /* 0 = Disabled, 1 = Enabled */
             R_ABORT_UNLESS(ParseSettingsItemValue("atmosphere", "enable_htc", "u8!0x0"));
 
+            /* Controls whether atmosphere's dmnt.gen2 gdbstub should run as a standalone via sockets. */
+            /* Note that this setting is ignored (and treated as 0) when htc is enabled. */
+            /* Note that this setting may disappear in the future. */
+            /* 0 = Disabled, 1 = Enabled */
+            R_ABORT_UNLESS(ParseSettingsItemValue("atmosphere", "enable_standalone_gdbstub", "u8!0x0"));
+
             /* Controls whether atmosphere's log manager is enabled. */
             /* Note that this setting is ignored (and treated as 1) when htc is enabled. */
             /* 0 = Disabled, 1 = Enabled */

--- a/stratosphere/creport/source/creport_modules.cpp
+++ b/stratosphere/creport/source/creport_modules.cpp
@@ -210,7 +210,7 @@ namespace ams::creport {
             }
 
             /* Also validate that we're looking at a valid name. */
-            if (rodata_start.module_path.zero != 0 || rodata_start.module_path.path_length <= 0)) {
+            if (rodata_start.module_path.zero != 0 || rodata_start.module_path.path_length <= 0) {
                 return;
             }
         }

--- a/stratosphere/dmnt.gen2/dmnt.gen2.json
+++ b/stratosphere/dmnt.gen2/dmnt.gen2.json
@@ -15,7 +15,7 @@
 	"filesystem_access":	{
 		"permissions":	"0xFFFFFFFFFFFFFFFF"
 	},
-	"service_access":	["pm:dmnt", "ldr:dmnt", "ro:dmnt", "ns:dev", "lr", "fsp-srv", "fatal:u", "pgl", "htcs"],
+	"service_access":	["pm:dmnt", "ldr:dmnt", "ro:dmnt", "ns:dev", "lr", "fsp-srv", "fatal:u", "pgl", "htcs", "bsd:s"],
 	"service_host":	[],
 	"kernel_capabilities":	[{
 			"type":	"kernel_flags",

--- a/stratosphere/dmnt.gen2/dmnt.gen2.json
+++ b/stratosphere/dmnt.gen2/dmnt.gen2.json
@@ -15,7 +15,7 @@
 	"filesystem_access":	{
 		"permissions":	"0xFFFFFFFFFFFFFFFF"
 	},
-	"service_access":	["pm:dmnt", "ldr:dmnt", "ro:dmnt", "ns:dev", "lr", "fsp-srv", "fatal:u", "pgl", "htcs", "bsd:s"],
+	"service_access":	["pm:dmnt", "ldr:dmnt", "ro:dmnt", "ns:dev", "lr", "fsp-srv", "fatal:u", "pgl", "htcs", "bsd:s", "set:sys"],
 	"service_host":	[],
 	"kernel_capabilities":	[{
 			"type":	"kernel_flags",

--- a/stratosphere/dmnt.gen2/source/dmnt2_debug_process.cpp
+++ b/stratosphere/dmnt.gen2/source/dmnt2_debug_process.cpp
@@ -27,9 +27,14 @@ namespace ams::dmnt {
 
     }
 
-    Result DebugProcess::Attach(os::ProcessId process_id) {
+    Result DebugProcess::Attach(os::ProcessId process_id, bool start_process) {
         /* Attach to the process. */
         R_TRY(svc::DebugActiveProcess(std::addressof(m_debug_handle), process_id.value));
+
+        /* If necessary, start the process. */
+        if (start_process) {
+            R_ABORT_UNLESS(pm::dmnt::StartProcess(process_id));
+        }
 
         /* Collect initial information. */
         R_TRY(this->Start());

--- a/stratosphere/dmnt.gen2/source/dmnt2_debug_process.cpp
+++ b/stratosphere/dmnt.gen2/source/dmnt2_debug_process.cpp
@@ -593,5 +593,25 @@ namespace ams::dmnt {
         return ResultSuccess();
     }
 
+    void DebugProcess::GetThreadName(char *dst, u64 thread_id) const {
+        for (size_t i = 0; i < ThreadCountMax; ++i) {
+            if (m_thread_valid[i] && m_thread_ids[i] == thread_id) {
+                if (R_FAILED(osdbg::GetThreadName(dst, std::addressof(m_thread_infos[i])))) {
+                    if (m_thread_infos[i]._thread_type != 0) {
+                        if (m_thread_infos[i]._thread_type_type == osdbg::ThreadTypeType_Libnx) {
+                            util::TSNPrintf(dst, os::ThreadNameLengthMax, "libnx Thread_%p", reinterpret_cast<void *>(m_thread_infos[i]._thread_type));
+                        } else {
+                            util::TSNPrintf(dst, os::ThreadNameLengthMax, "Thread_%p", reinterpret_cast<void *>(m_thread_infos[i]._thread_type));
+                        }
+                    } else {
+                        break;
+                    }
+                }
+                return;
+            }
+        }
+
+        util::TSNPrintf(dst, os::ThreadNameLengthMax, "Thread_ID=%lu", thread_id);
+    }
 
 }

--- a/stratosphere/dmnt.gen2/source/dmnt2_debug_process.cpp
+++ b/stratosphere/dmnt.gen2/source/dmnt2_debug_process.cpp
@@ -601,9 +601,9 @@ namespace ams::dmnt {
                 if (R_FAILED(osdbg::GetThreadName(dst, std::addressof(m_thread_infos[i])))) {
                     if (m_thread_infos[i]._thread_type != 0) {
                         if (m_thread_infos[i]._thread_type_type == osdbg::ThreadTypeType_Libnx) {
-                            util::TSNPrintf(dst, os::ThreadNameLengthMax, "libnx Thread_%p", reinterpret_cast<void *>(m_thread_infos[i]._thread_type));
+                            util::TSNPrintf(dst, os::ThreadNameLengthMax, "libnx Thread_0x%010lx", reinterpret_cast<uintptr_t>(m_thread_infos[i]._thread_type));
                         } else {
-                            util::TSNPrintf(dst, os::ThreadNameLengthMax, "Thread_%p", reinterpret_cast<void *>(m_thread_infos[i]._thread_type));
+                            util::TSNPrintf(dst, os::ThreadNameLengthMax, "Thread_0x%010lx", reinterpret_cast<uintptr_t>(m_thread_infos[i]._thread_type));
                         }
                     } else {
                         break;

--- a/stratosphere/dmnt.gen2/source/dmnt2_debug_process.cpp
+++ b/stratosphere/dmnt.gen2/source/dmnt2_debug_process.cpp
@@ -196,9 +196,11 @@ namespace ams::dmnt {
                         char path[ModuleDefinition::PathLengthMax];
                     } module_path;
                     if (R_SUCCEEDED(this->ReadMemory(std::addressof(module_path), memory_info.base_address + memory_info.size, sizeof(module_path)))) {
-                        if (module_path.zero == 0 && module_path.path_length == util::Strnlen(module_path.path, sizeof(module_path.path))) {
-                            std::memcpy(module_name, module_path.path, ModuleDefinition::PathLengthMax);
+                        if (module_path.zero == 0 && module_path.path_length > 0) {
+                            std::memcpy(module_name, module_path.path, std::min<size_t>(ModuleDefinition::PathLengthMax, module_path.path_length));
                         }
+                    } else {
+                        module_path.path_length = 0;
                     }
 
                     /* Truncate module name. */
@@ -208,7 +210,7 @@ namespace ams::dmnt {
                     module.SetNameStart(0);
 
                     /* Ignore leading directories. */
-                    for (size_t i = 0; i < static_cast<size_t>(module_path.path_length); ++i) {
+                    for (size_t i = 0; i < std::min<size_t>(ModuleDefinition::PathLengthMax, module_path.path_length) && module_name[i] != 0; ++i) {
                         if (module_name[i] == '/' || module_name[i] == '\\') {
                             module.SetNameStart(i + 1);
                         }

--- a/stratosphere/dmnt.gen2/source/dmnt2_debug_process.cpp
+++ b/stratosphere/dmnt.gen2/source/dmnt2_debug_process.cpp
@@ -194,6 +194,16 @@ namespace ams::dmnt {
 
                     /* Truncate module name. */
                     module_name[ModuleDefinition::PathLengthMax - 1] = 0;
+
+                    /* Set default module name start. */
+                    module.SetNameStart(0);
+
+                    /* Ignore leading directories. */
+                    for (size_t i = 0; i < static_cast<size_t>(module_path.path_length); ++i) {
+                        if (module_name[i] == '/' || module_name[i] == '\\') {
+                            module.SetNameStart(i + 1);
+                        }
+                    }
                 }
             }
 
@@ -226,6 +236,11 @@ namespace ams::dmnt {
 
     Result DebugProcess::WriteMemory(const void *src, uintptr_t address, size_t size) {
         return svc::WriteDebugProcessMemory(m_debug_handle, reinterpret_cast<uintptr_t>(src), address, size);
+    }
+
+    Result DebugProcess::QueryMemory(svc::MemoryInfo *out, uintptr_t address) {
+        svc::PageInfo dummy;
+        return svc::QueryDebugProcessMemory(out, std::addressof(dummy), m_debug_handle, address);
     }
 
     Result DebugProcess::Continue() {

--- a/stratosphere/dmnt.gen2/source/dmnt2_debug_process.hpp
+++ b/stratosphere/dmnt.gen2/source/dmnt2_debug_process.hpp
@@ -117,6 +117,8 @@ namespace ams::dmnt {
             Result ReadMemory(void *dst, uintptr_t address, size_t size);
             Result WriteMemory(const void *src, uintptr_t address, size_t size);
 
+            Result QueryMemory(svc::MemoryInfo *out, uintptr_t address);
+
             Result Continue();
             Result Continue(u64 thread_id);
             Result Step();

--- a/stratosphere/dmnt.gen2/source/dmnt2_debug_process.hpp
+++ b/stratosphere/dmnt.gen2/source/dmnt2_debug_process.hpp
@@ -50,6 +50,7 @@ namespace ams::dmnt {
             u64 m_last_thread_id{};
             u64 m_thread_id_override{};
             u64 m_continue_thread_id{};
+            u64 m_preferred_debug_break_thread_id{};
             GdbSignal m_last_signal{};
             bool m_stepping{false};
             bool m_use_hardware_single_step{false};
@@ -107,13 +108,16 @@ namespace ams::dmnt {
             u64 GetLastThreadId();
             u64 GetThreadIdOverride() { this->GetLastThreadId(); return m_thread_id_override; }
 
+            u64 GetPreferredDebuggerBreakThreadId() { return m_preferred_debug_break_thread_id; }
+
             void SetLastThreadId(u64 tid) {
                 m_last_thread_id     = tid;
                 m_thread_id_override = tid;
             }
 
             void SetThreadIdOverride(u64 tid) {
-                m_thread_id_override = tid;
+                m_thread_id_override              = tid;
+                m_preferred_debug_break_thread_id = tid;
             }
 
             void SetDebugBreaked() {
@@ -174,6 +178,8 @@ namespace ams::dmnt {
             void GetBranchTarget(svc::ThreadContext &ctx, u64 thread_id, u64 &current_pc, u64 &target);
 
             Result CollectModules();
+
+            void GetThreadName(char *dst, u64 thread_id) const;
         private:
             Result Start();
 

--- a/stratosphere/dmnt.gen2/source/dmnt2_debug_process.hpp
+++ b/stratosphere/dmnt.gen2/source/dmnt2_debug_process.hpp
@@ -109,7 +109,7 @@ namespace ams::dmnt {
                 m_status = ProcessStatus_DebugBreak;
             }
         public:
-            Result Attach(os::ProcessId process_id);
+            Result Attach(os::ProcessId process_id, bool start_process = false);
             void Detach();
 
             Result GetThreadContext(svc::ThreadContext *out, u64 thread_id, u32 flags);

--- a/stratosphere/dmnt.gen2/source/dmnt2_debug_process.hpp
+++ b/stratosphere/dmnt.gen2/source/dmnt2_debug_process.hpp
@@ -64,6 +64,17 @@ namespace ams::dmnt {
             ModuleDefinition m_module_definitions[ModuleCountMax]{};
             size_t m_module_count{};
             size_t m_main_module{};
+            u64 m_process_alias_address{};
+            u64 m_process_alias_size{};
+            u64 m_process_heap_address{};
+            u64 m_process_heap_size{};
+            u64 m_process_aslr_address{};
+            u64 m_process_aslr_size{};
+            u64 m_process_stack_address{};
+            u64 m_process_stack_size{};
+            ncm::ProgramLocation m_program_location{};
+            cfg::OverrideStatus m_process_override_status{};
+            bool m_is_application{false};
         public:
             DebugProcess() : m_software_breakpoints(this), m_hardware_breakpoints(this), m_hardware_watchpoints(this), m_step_breakpoints(m_software_breakpoints) {
                 if (svc::IsKernelMesosphere()) {
@@ -108,6 +119,20 @@ namespace ams::dmnt {
             void SetDebugBreaked() {
                 m_status = ProcessStatus_DebugBreak;
             }
+
+            u64 GetAliasRegionAddress() const { return m_process_alias_address; }
+            u64 GetAliasRegionSize()    const { return m_process_alias_size; }
+            u64 GetHeapRegionAddress()  const { return m_process_heap_address; }
+            u64 GetHeapRegionSize()     const { return m_process_heap_size; }
+            u64 GetAslrRegionAddress()  const { return m_process_aslr_address; }
+            u64 GetAslrRegionSize()     const { return m_process_aslr_size; }
+            u64 GetStackRegionAddress() const { return m_process_stack_address; }
+            u64 GetStackRegionSize()    const { return m_process_stack_size; }
+
+            const ncm::ProgramLocation &GetProgramLocation() const { return m_program_location; }
+            const cfg::OverrideStatus &GetOverrideStatus() const { return m_process_override_status; }
+
+            bool IsApplication() const { return m_is_application; }
         public:
             Result Attach(os::ProcessId process_id, bool start_process = false);
             void Detach();
@@ -151,6 +176,8 @@ namespace ams::dmnt {
             Result CollectModules();
         private:
             Result Start();
+
+            void CollectProcessInfo();
 
             s32 ThreadCreate(u64 thread_id);
             void ThreadExit(u64 thread_id);

--- a/stratosphere/dmnt.gen2/source/dmnt2_debug_process.hpp
+++ b/stratosphere/dmnt.gen2/source/dmnt2_debug_process.hpp
@@ -80,7 +80,8 @@ namespace ams::dmnt {
             size_t GetModuleCount() const { return m_module_count; }
             size_t GetMainModuleIndex() const { return m_main_module; }
             const char *GetModuleName(size_t ix) const { return m_module_definitions[ix].GetName(); }
-            uintptr_t GetBaseAddress(size_t ix) const { return m_module_definitions[ix].GetAddress(); }
+            uintptr_t GetModuleBaseAddress(size_t ix) const { return m_module_definitions[ix].GetAddress(); }
+            uintptr_t GetModuleSize(size_t ix) const { return m_module_definitions[ix].GetSize(); }
             ProcessStatus GetStatus() const { return m_status; }
             os::ProcessId GetProcessId() const { return m_process_id; }
 

--- a/stratosphere/dmnt.gen2/source/dmnt2_gdb_packet_io.cpp
+++ b/stratosphere/dmnt.gen2/source/dmnt2_gdb_packet_io.cpp
@@ -41,7 +41,7 @@ namespace ams::dmnt {
 
     }
 
-    void GdbPacketIo::SendPacket(bool *out_break, const char *src, HtcsSession *session) {
+    void GdbPacketIo::SendPacket(bool *out_break, const char *src, TransportSession *session) {
         /* Default to not breaked. */
         *out_break = false;
 
@@ -99,7 +99,7 @@ namespace ams::dmnt {
         }
     }
 
-    char *GdbPacketIo::ReceivePacket(bool *out_break, char *dst, size_t size, HtcsSession *session) {
+    char *GdbPacketIo::ReceivePacket(bool *out_break, char *dst, size_t size, TransportSession *session) {
         /* Default to not breaked. */
         *out_break = false;
 

--- a/stratosphere/dmnt.gen2/source/dmnt2_gdb_packet_io.hpp
+++ b/stratosphere/dmnt.gen2/source/dmnt2_gdb_packet_io.hpp
@@ -19,7 +19,7 @@
 
 namespace ams::dmnt {
 
-    static constexpr size_t GdbPacketBufferSize = 16_KB;
+    static constexpr size_t GdbPacketBufferSize = 32_KB;
 
     class GdbPacketIo {
         private:

--- a/stratosphere/dmnt.gen2/source/dmnt2_gdb_server_impl.cpp
+++ b/stratosphere/dmnt.gen2/source/dmnt2_gdb_server_impl.cpp
@@ -772,7 +772,6 @@ namespace ams::dmnt {
             AnnexBufferContents_Processes,
             AnnexBufferContents_Threads,
             AnnexBufferContents_Libraries,
-            AnnexBufferContents_MemoryMap,
         };
 
         constinit AnnexBufferContents g_annex_buffer_contents = AnnexBufferContents_Invalid;
@@ -1954,7 +1953,6 @@ namespace ams::dmnt {
         AppendReply(m_reply_packet, ";augmented-libraries-svr4-read+");
         AppendReply(m_reply_packet, ";qXfer:threads:read+");
         AppendReply(m_reply_packet, ";qXfer:exec-file:read+");
-        AppendReply(m_reply_packet, ";qXfer:memory-map:read+");
         AppendReply(m_reply_packet, ";swbreak+");
         AppendReply(m_reply_packet, ";hwbreak+");
         AppendReply(m_reply_packet, ";vContSupported+");
@@ -1981,8 +1979,6 @@ namespace ams::dmnt {
                 }
             } else if (ParsePrefix(m_receive_packet, "libraries:read::")) {
                 this->qXferLibrariesRead();
-            } else if (ParsePrefix(m_receive_packet, "memory-map:read::")) {
-                this->qXferMemoryMapRead();
             } else if (ParsePrefix(m_receive_packet, "exec-file:read:")) {
                 SetReply(m_reply_packet, "l%s", m_debug_process.GetProcessName());
             } else {
@@ -2073,73 +2069,6 @@ namespace ams::dmnt {
             AppendReply(g_annex_buffer, "</library-list>");
 
             g_annex_buffer_contents = AnnexBufferContents_Libraries;
-        }
-
-        /* Copy out the module list. */
-        GetAnnexBufferContents(m_reply_packet, offset, length);
-    }
-
-    void GdbServerImpl::qXferMemoryMapRead() {
-        /* Handle the qXfer. */
-        u32 offset, length;
-
-        /* Parse offset/length. */
-        ParseOffsetLength(m_receive_packet, offset, length);
-
-        /* Acquire access to the annex buffer. */
-        std::scoped_lock lk(g_annex_buffer_lock);
-
-        /* If doing a fresh read, generate the module list. */
-        if (offset == 0 || g_annex_buffer_contents != AnnexBufferContents_MemoryMap) {
-            /* Set header. */
-            SetReply(g_annex_buffer, "<memory-map>\n");
-
-            /* Iterate over all mappings. */
-            uintptr_t cur_addr = 0;
-            svc::MemoryInfo prev_info = {};
-            size_t prev_size = 0;
-            while (true) {
-                /* Get current mapping. */
-                svc::MemoryInfo mem_info;
-                if (R_FAILED(m_debug_process.QueryMemory(std::addressof(mem_info), cur_addr))) {
-                    break;
-                }
-
-                /* If the mapping is present, add it. */
-                if (mem_info.state != svc::MemoryState_Free && mem_info.state != svc::MemoryState_Inaccessible && mem_info.permission != svc::MemoryPermission_None) {
-                    if (prev_size != 0 && mem_info.state == prev_info.state && mem_info.permission == prev_info.permission && mem_info.attribute == prev_info.attribute && mem_info.base_address == prev_info.base_address + prev_size) {
-                        prev_size += mem_info.size;
-                    } else {
-                        if (prev_size != 0) {
-                            AppendReply(g_annex_buffer, "<memory type=\"ram\" start=\"0x%lx\" length=\"0x%lx\" />", prev_info.base_address, prev_size);
-                        }
-
-                        prev_info = mem_info;
-                        prev_size = mem_info.size;
-                    }
-                } else {
-                    if (prev_size != 0) {
-                        AppendReply(g_annex_buffer, "<memory type=\"ram\" start=\"0x%lx\" length=\"0x%lx\" />", prev_info.base_address, prev_size);
-
-                        prev_size = 0;
-                    }
-                }
-
-                const uintptr_t next_address = mem_info.base_address + mem_info.size;
-                if (next_address <= cur_addr) {
-                    break;
-                }
-
-                cur_addr = next_address;
-            }
-
-            if (prev_size != 0) {
-                AppendReply(g_annex_buffer, "<memory type=\"ram\" start=\"0x%lx\" length=\"0x%lx\" />", prev_info.base_address, prev_size);
-            }
-
-            AppendReply(g_annex_buffer, "</memory-map>");
-
-            g_annex_buffer_contents = AnnexBufferContents_MemoryMap;
         }
 
         /* Copy out the module list. */

--- a/stratosphere/dmnt.gen2/source/dmnt2_gdb_server_impl.cpp
+++ b/stratosphere/dmnt.gen2/source/dmnt2_gdb_server_impl.cpp
@@ -2061,7 +2061,7 @@ namespace ams::dmnt {
             SetReply(m_buffer, "[TODO] wait for program id 0x%lx\n", program_id);
         } else {
             SetReply(m_reply_packet, "Unknown command `%s`\n", command);
-            std::memcpy(m_buffer, m_reply_packet, std::strlen(m_reply_packet));
+            std::memcpy(m_buffer, m_reply_packet, std::strlen(m_reply_packet) + 1);
         }
     }
 

--- a/stratosphere/dmnt.gen2/source/dmnt2_gdb_server_impl.cpp
+++ b/stratosphere/dmnt.gen2/source/dmnt2_gdb_server_impl.cpp
@@ -433,7 +433,7 @@ namespace ams::dmnt {
             return 0;
         }
 
-        void SetGdbRegister32(char *dst, char * const dst_end, u32 value) {
+        void SetGdbRegister32(char * &dst, char * const dst_end, u32 value) {
             if (value != 0) {
                 AppendReplyFormat(dst, dst_end, "%08x", util::ConvertToBigEndian(value));
             } else {
@@ -441,7 +441,7 @@ namespace ams::dmnt {
             }
         }
 
-        void SetGdbRegister64(char *dst, char * const dst_end, u64 value) {
+        void SetGdbRegister64(char * &dst, char * const dst_end, u64 value) {
             if (value != 0) {
                 AppendReplyFormat(dst, dst_end, "%016lx", util::ConvertToBigEndian(value));
             } else {
@@ -449,7 +449,7 @@ namespace ams::dmnt {
             }
         }
 
-        void SetGdbRegister128(char *dst, char * const dst_end, u128 value) {
+        void SetGdbRegister128(char * &dst, char * const dst_end, u128 value) {
             if (value != 0) {
                 AppendReplyFormat(dst, dst_end, "%016lx%016lx", util::ConvertToBigEndian(static_cast<u64>(value >> 0)), util::ConvertToBigEndian(static_cast<u64>(value >> BITSIZEOF(u64))));
             } else {
@@ -457,7 +457,7 @@ namespace ams::dmnt {
             }
         }
 
-        void SetGdbRegisterPacket(char *dst, char * const dst_end, const svc::ThreadContext &thread_context, bool is_64_bit) {
+        void SetGdbRegisterPacket(char * &dst, char * const dst_end, const svc::ThreadContext &thread_context, bool is_64_bit) {
             /* Clear packet. */
             dst[0] = 0;
 
@@ -502,7 +502,7 @@ namespace ams::dmnt {
             }
         }
 
-        void SetGdbRegisterPacket(char *dst, char * const dst_end, const svc::ThreadContext &thread_context, u64 reg_num, bool is_64_bit) {
+        void SetGdbRegisterPacket(char * &dst, char * const dst_end, const svc::ThreadContext &thread_context, u64 reg_num, bool is_64_bit) {
             /* Clear packet. */
             dst[0] = 0;
 

--- a/stratosphere/dmnt.gen2/source/dmnt2_gdb_server_impl.hpp
+++ b/stratosphere/dmnt.gen2/source/dmnt2_gdb_server_impl.hpp
@@ -102,6 +102,7 @@ namespace ams::dmnt {
             void qXfer();
             void qXferFeaturesRead();
             void qXferLibrariesRead();
+            void qXferMemoryMapRead();
             void qXferOsdataRead();
             bool qXferThreadsRead();
 

--- a/stratosphere/dmnt.gen2/source/dmnt2_gdb_server_impl.hpp
+++ b/stratosphere/dmnt.gen2/source/dmnt2_gdb_server_impl.hpp
@@ -42,6 +42,7 @@ namespace ams::dmnt {
             DebugProcess m_debug_process;
             os::ProcessId m_process_id{os::InvalidProcessId};
             os::Event m_event;
+            os::ProcessId m_wait_process_id{os::InvalidProcessId};
         public:
             GdbServerImpl(int socket, void *thread_stack, size_t stack_size);
             ~GdbServerImpl();

--- a/stratosphere/dmnt.gen2/source/dmnt2_gdb_server_impl.hpp
+++ b/stratosphere/dmnt.gen2/source/dmnt2_gdb_server_impl.hpp
@@ -104,7 +104,6 @@ namespace ams::dmnt {
             void qXfer();
             void qXferFeaturesRead();
             void qXferLibrariesRead();
-            void qXferMemoryMapRead();
             void qXferOsdataRead();
             bool qXferThreadsRead();
 

--- a/stratosphere/dmnt.gen2/source/dmnt2_gdb_server_impl.hpp
+++ b/stratosphere/dmnt.gen2/source/dmnt2_gdb_server_impl.hpp
@@ -34,7 +34,8 @@ namespace ams::dmnt {
             TransportSession m_session;
             GdbPacketIo m_packet_io;
             char *m_receive_packet{nullptr};
-            char *m_reply_packet{nullptr};
+            char *m_reply_cur{nullptr};
+            char *m_reply_end{nullptr};
             char m_buffer[GdbPacketBufferSize / 2];
             bool m_killed{false};
             os::ThreadType m_events_thread;
@@ -61,7 +62,7 @@ namespace ams::dmnt {
             static void DebugEventsThreadEntry(void *arg) { static_cast<GdbServerImpl *>(arg)->DebugEventsThread(); }
             void DebugEventsThread();
             void ProcessDebugEvents();
-            void SetStopReplyPacket(GdbSignal signal);
+            void AppendStopReplyPacket(GdbSignal signal);
         private:
             void D();
 

--- a/stratosphere/dmnt.gen2/source/dmnt2_gdb_server_impl.hpp
+++ b/stratosphere/dmnt.gen2/source/dmnt2_gdb_server_impl.hpp
@@ -31,7 +31,7 @@ namespace ams::dmnt {
             };
         private:
             int m_socket;
-            HtcsSession m_session;
+            TransportSession m_session;
             GdbPacketIo m_packet_io;
             char *m_receive_packet{nullptr};
             char *m_reply_packet{nullptr};

--- a/stratosphere/dmnt.gen2/source/dmnt2_gdb_server_impl.hpp
+++ b/stratosphere/dmnt.gen2/source/dmnt2_gdb_server_impl.hpp
@@ -98,6 +98,7 @@ namespace ams::dmnt {
 
             void qAttached();
             void qC();
+            void qRcmd();
             void qSupported();
             void qXfer();
             void qXferFeaturesRead();

--- a/stratosphere/dmnt.gen2/source/dmnt2_main.cpp
+++ b/stratosphere/dmnt.gen2/source/dmnt2_main.cpp
@@ -42,6 +42,9 @@ namespace ams {
             /* Initialize our connection to sm. */
             R_ABORT_UNLESS(sm::Initialize());
 
+            /* Initialize other services we need. */
+            R_ABORT_UNLESS(pmdmntInitialize());
+
             /* Verify that we can sanely execute. */
             ams::CheckApiVersion();
         }

--- a/stratosphere/dmnt.gen2/source/dmnt2_module_definition.hpp
+++ b/stratosphere/dmnt.gen2/source/dmnt2_module_definition.hpp
@@ -26,6 +26,7 @@ namespace ams::dmnt {
             char m_name[PathLengthMax];
             u64 m_address;
             u64 m_size;
+            size_t m_name_start;
         public:
             constexpr ModuleDefinition() : m_name(), m_address(), m_size() { /* ... */ }
             constexpr ~ModuleDefinition() { /* ... */ }
@@ -34,9 +35,10 @@ namespace ams::dmnt {
             constexpr ModuleDefinition &operator=(const ModuleDefinition &rhs) = default;
 
             constexpr void Reset() {
-                m_name[0] = 0;
-                m_address = 0;
-                m_size    = 0;
+                m_name[0]    = 0;
+                m_address    = 0;
+                m_size       = 0;
+                m_name_start = 0;
             }
 
             constexpr bool operator==(const ModuleDefinition &rhs) const {
@@ -48,7 +50,7 @@ namespace ams::dmnt {
             }
 
             constexpr char *GetNameBuffer() { return m_name; }
-            constexpr const char *GetName() const { return m_name; }
+            constexpr const char *GetName() const { return m_name + m_name_start; }
 
             constexpr u64 GetAddress() const { return m_address; }
             constexpr u64 GetSize() const { return m_size; }
@@ -56,6 +58,10 @@ namespace ams::dmnt {
             constexpr void SetAddressSize(u64 address, u64 size) {
                 m_address = address;
                 m_size    = size;
+            }
+
+            constexpr void SetNameStart(size_t offset) {
+                m_name_start = offset;
             }
     };
 

--- a/stratosphere/dmnt.gen2/source/dmnt2_transport_layer.cpp
+++ b/stratosphere/dmnt.gen2/source/dmnt2_transport_layer.cpp
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) Atmosphère-NX
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <stratosphere.hpp>
+#include "dmnt2_transport_layer.hpp"
+
+namespace ams::dmnt::transport {
+
+    namespace {
+
+        enum SocketMode {
+            SocketMode_Invalid,
+            SocketMode_Htcs,
+            SocketMode_Tcp,
+        };
+
+        constexpr inline const u16 ListenPort_GdbServer   = 22225;
+        constexpr inline const u16 ListenPort_GdbDebugLog = 22227;
+
+        constinit os::SdkMutex g_socket_init_mutex;
+        constinit SocketMode g_socket_mode = SocketMode_Invalid;
+
+        constexpr inline size_t RequiredAlignment = std::max(os::ThreadStackAlignment, os::MemoryPageSize);
+
+        using SocketConfigType = socket::SystemConfigLightDefault;
+
+        /* TODO: If we ever use resolvers, increase this. */
+        constexpr inline size_t SocketAllocatorSize  = 4_KB;
+        constexpr inline size_t SocketMemoryPoolSize = util::AlignUp(SocketConfigType::PerTcpSocketWorstCaseMemoryPoolSize + SocketConfigType::PerUdpSocketWorstCaseMemoryPoolSize, os::MemoryPageSize);
+
+        constexpr inline size_t SocketRequiredSize   = util::AlignUp(SocketMemoryPoolSize + SocketAllocatorSize, os::MemoryPageSize);
+
+        /* Declare the memory pool. */
+        alignas(RequiredAlignment) constinit u8 g_socket_memory[SocketRequiredSize];
+
+        constexpr inline const SocketConfigType SocketConfig(g_socket_memory, SocketRequiredSize, SocketAllocatorSize, 2);
+
+    }
+
+    void InitializeByHtcs() {
+        std::scoped_lock lk(g_socket_init_mutex);
+        AMS_ABORT_UNLESS(g_socket_mode == SocketMode_Invalid);
+
+        constexpr auto HtcsSocketCountMax = 8;
+        const size_t buffer_size = htcs::GetWorkingMemorySize(HtcsSocketCountMax);
+        AMS_ABORT_UNLESS(sizeof(g_socket_memory) >= buffer_size);
+        htcs::InitializeForSystem(g_socket_memory, sizeof(g_socket_memory), HtcsSocketCountMax);
+
+        g_socket_mode = SocketMode_Htcs;
+    }
+
+    void InitializeByTcp() {
+        std::scoped_lock lk(g_socket_init_mutex);
+        AMS_ABORT_UNLESS(g_socket_mode == SocketMode_Invalid);
+
+        R_ABORT_UNLESS(socket::Initialize(SocketConfig));
+
+        g_socket_mode = SocketMode_Tcp;
+    }
+
+    s32 Socket() {
+        switch (g_socket_mode) {
+            case SocketMode_Htcs: return htcs::Socket();
+            case SocketMode_Tcp:  return socket::Socket(socket::Family::Af_Inet, socket::Type::Sock_Stream, socket::Protocol::IpProto_Tcp);
+            AMS_UNREACHABLE_DEFAULT_CASE();
+        }
+    }
+
+    s32 Close(s32 desc) {
+        switch (g_socket_mode) {
+            case SocketMode_Htcs:   return htcs::Close(desc);
+            case SocketMode_Tcp: return socket::Close(desc);
+            AMS_UNREACHABLE_DEFAULT_CASE();
+        }
+    }
+
+    s32 Bind(s32 desc, PortName port_name) {
+        switch (g_socket_mode) {
+            case SocketMode_Htcs:
+                {
+                    htcs::SockAddrHtcs addr;
+                    addr.family    = htcs::HTCS_AF_HTCS;
+                    addr.peer_name = htcs::GetPeerNameAny();
+                    switch (port_name) {
+                        case PortName_GdbServer:   std::strcpy(addr.port_name.name, "iywys@$gdb"); break;
+                        case PortName_GdbDebugLog: std::strcpy(addr.port_name.name, "iywys@$dmnt2_log"); break;
+                        AMS_UNREACHABLE_DEFAULT_CASE();
+                    }
+
+                    return htcs::Bind(desc, std::addressof(addr));
+                }
+                break;
+            case SocketMode_Tcp:
+                {
+                    socket::SockAddrIn addr = {};
+                    addr.sin_family      = socket::Family::Af_Inet;
+                    addr.sin_addr.s_addr = socket::InAddr_Any;
+
+                    switch (port_name){
+                        case PortName_GdbServer:   addr.sin_port = socket::InetHtons(static_cast<u16>(ListenPort_GdbServer)); break;
+                        case PortName_GdbDebugLog: addr.sin_port = socket::InetHtons(static_cast<u16>(ListenPort_GdbDebugLog)); break;
+                        AMS_UNREACHABLE_DEFAULT_CASE();
+                    }
+
+                    return socket::Bind(desc, reinterpret_cast<socket::SockAddr *>(std::addressof(addr)), sizeof(addr));
+                }
+                break;
+            AMS_UNREACHABLE_DEFAULT_CASE();
+        }
+    }
+
+    s32 Listen(s32 desc, s32 backlog_count) {
+        switch (g_socket_mode) {
+            case SocketMode_Htcs: return htcs::Listen(desc, backlog_count);
+            case SocketMode_Tcp:  return socket::Listen(desc, backlog_count);
+            AMS_UNREACHABLE_DEFAULT_CASE();
+        }
+    }
+
+    s32 Accept(s32 desc) {
+        switch (g_socket_mode) {
+            case SocketMode_Htcs:
+                {
+                    htcs::SockAddrHtcs addr;
+                    addr.family    = htcs::HTCS_AF_HTCS;
+                    addr.peer_name = htcs::GetPeerNameAny();
+                    addr.port_name.name[0] = '\x00';
+
+                    return htcs::Accept(desc, std::addressof(addr));
+                }
+                break;
+            case SocketMode_Tcp:
+                {
+                    socket::SockAddrIn addr = {};
+                    socket::SockLenT addr_len = sizeof(addr);
+
+                    return socket::Accept(desc, reinterpret_cast<socket::SockAddr *>(std::addressof(addr)), std::addressof(addr_len));
+                }
+                break;
+            AMS_UNREACHABLE_DEFAULT_CASE();
+        }
+    }
+
+    s32 Shutdown(s32 desc) {
+        switch (g_socket_mode) {
+            case SocketMode_Htcs: return htcs::Shutdown(desc, htcs::HTCS_SHUT_RDWR);
+            case SocketMode_Tcp:  return socket::Shutdown(desc, socket::ShutdownMethod::Shut_RdWr);
+            AMS_UNREACHABLE_DEFAULT_CASE();
+        }
+    }
+
+    ssize_t Recv(s32 desc, void *buffer, size_t buffer_size, s32 flags) {
+        switch (g_socket_mode) {
+            case SocketMode_Htcs: return htcs::Recv(desc, buffer, buffer_size, flags);
+            case SocketMode_Tcp:  return socket::Recv(desc, buffer, buffer_size, static_cast<socket::MsgFlag>(flags));
+            AMS_UNREACHABLE_DEFAULT_CASE();
+        }
+    }
+
+    ssize_t Send(s32 desc, const void *buffer, size_t buffer_size, s32 flags) {
+        switch (g_socket_mode) {
+            case SocketMode_Htcs: return htcs::Send(desc, buffer, buffer_size, flags);
+            case SocketMode_Tcp:  return socket::Send(desc, buffer, buffer_size, static_cast<socket::MsgFlag>(flags));
+            AMS_UNREACHABLE_DEFAULT_CASE();
+        }
+    }
+
+    s32 GetLastError() {
+        switch (g_socket_mode) {
+            case SocketMode_Htcs: return htcs::GetLastError();
+            case SocketMode_Tcp:  return static_cast<s32>(socket::GetLastError());
+            AMS_UNREACHABLE_DEFAULT_CASE();
+        }
+    }
+
+    bool IsLastErrorEAgain() {
+        switch (g_socket_mode) {
+            case SocketMode_Htcs: return htcs::GetLastError() == htcs::HTCS_EAGAIN;
+            case SocketMode_Tcp:  return socket::GetLastError() == socket::Errno::EAgain;
+            AMS_UNREACHABLE_DEFAULT_CASE();
+        }
+    }
+
+}

--- a/stratosphere/dmnt.gen2/source/dmnt2_transport_layer.hpp
+++ b/stratosphere/dmnt.gen2/source/dmnt2_transport_layer.hpp
@@ -15,23 +15,28 @@
  */
 #pragma once
 #include <stratosphere.hpp>
-#include "dmnt2_transport_session.hpp"
 
-namespace ams::dmnt {
+namespace ams::dmnt::transport {
 
-    static constexpr size_t GdbPacketBufferSize = 16_KB;
+    void InitializeByHtcs();
+    void InitializeByTcp();
 
-    class GdbPacketIo {
-        private:
-            os::SdkMutex m_mutex;
-            bool m_no_ack;
-        public:
-            GdbPacketIo() : m_mutex(), m_no_ack(false) { /* ... */ }
-
-            void SetNoAck() { m_no_ack = true; }
-
-            void SendPacket(bool *out_break, const char *src, TransportSession *session);
-            char *ReceivePacket(bool *out_break, char *dst, size_t size, TransportSession *session);
+    enum PortName {
+        PortName_GdbServer,
+        PortName_GdbDebugLog,
     };
+
+    s32 Socket();
+    s32 Close(s32 desc);
+    s32 Bind(s32 desc, PortName port_name);
+    s32 Listen(s32 desc, s32 backlog_count);
+    s32 Accept(s32 desc);
+    s32 Shutdown(s32 desc);
+
+    ssize_t Recv(s32 desc, void *buffer, size_t buffer_size, s32 flags);
+    ssize_t Send(s32 desc, const void *buffer, size_t buffer_size, s32 flags);
+
+    s32 GetLastError();
+    bool IsLastErrorEAgain();
 
 }

--- a/stratosphere/dmnt.gen2/source/dmnt2_transport_receive_buffer.cpp
+++ b/stratosphere/dmnt.gen2/source/dmnt2_transport_receive_buffer.cpp
@@ -14,11 +14,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include <stratosphere.hpp>
-#include "dmnt2_htcs_receive_buffer.hpp"
+#include "dmnt2_transport_receive_buffer.hpp"
 
 namespace ams::dmnt {
 
-    ssize_t HtcsReceiveBuffer::Read(void *dst, size_t size) {
+    ssize_t TransportReceiveBuffer::Read(void *dst, size_t size) {
         /* Acquire exclusive access to ourselves. */
         std::scoped_lock lk(m_mutex);
 
@@ -50,7 +50,7 @@ namespace ams::dmnt {
         return readable;
     }
 
-    ssize_t HtcsReceiveBuffer::Write(const void *src, size_t size) {
+    ssize_t TransportReceiveBuffer::Write(const void *src, size_t size) {
         /* Acquire exclusive access to ourselves. */
         std::scoped_lock lk(m_mutex);
 
@@ -71,7 +71,7 @@ namespace ams::dmnt {
         return size;
     }
 
-    bool HtcsReceiveBuffer::WaitToBeReadable() {
+    bool TransportReceiveBuffer::WaitToBeReadable() {
         /* Check if we're already readable. */
         {
             std::scoped_lock lk(m_mutex);
@@ -91,7 +91,7 @@ namespace ams::dmnt {
         return this->IsValid();
     }
 
-    bool HtcsReceiveBuffer::WaitToBeReadable(TimeSpan timeout) {
+    bool TransportReceiveBuffer::WaitToBeReadable(TimeSpan timeout) {
         /* Check if we're already readable. */
         {
             std::scoped_lock lk(m_mutex);
@@ -111,7 +111,7 @@ namespace ams::dmnt {
         return res && this->IsValid();
     }
 
-    bool HtcsReceiveBuffer::WaitToBeWritable() {
+    bool TransportReceiveBuffer::WaitToBeWritable() {
         /* Check if we're already writable. */
         {
             std::scoped_lock lk(m_mutex);
@@ -131,7 +131,7 @@ namespace ams::dmnt {
         return this->IsValid();
     }
 
-    void HtcsReceiveBuffer::Invalidate() {
+    void TransportReceiveBuffer::Invalidate() {
         /* Acquire exclusive access to ourselves. */
         std::scoped_lock lk(m_mutex);
 

--- a/stratosphere/dmnt.gen2/source/dmnt2_transport_receive_buffer.hpp
+++ b/stratosphere/dmnt.gen2/source/dmnt2_transport_receive_buffer.hpp
@@ -18,7 +18,7 @@
 
 namespace ams::dmnt {
 
-    class HtcsReceiveBuffer {
+    class TransportReceiveBuffer {
         public:
             static constexpr size_t ReceiveBufferSize = 4_KB;
         private:
@@ -30,7 +30,7 @@ namespace ams::dmnt {
             size_t m_offset;
             bool m_valid;
         public:
-            HtcsReceiveBuffer() : m_readable_event(os::EventClearMode_ManualClear), m_writable_event(os::EventClearMode_ManualClear), m_mutex(), m_readable_size(), m_offset(), m_valid(true) { /* ... */ }
+            TransportReceiveBuffer() : m_readable_event(os::EventClearMode_ManualClear), m_writable_event(os::EventClearMode_ManualClear), m_mutex(), m_readable_size(), m_offset(), m_valid(true) { /* ... */ }
 
             ALWAYS_INLINE bool IsReadable() const { return m_readable_size != 0; }
             ALWAYS_INLINE bool IsWritable() const { return m_readable_size == 0; }

--- a/stratosphere/dmnt.gen2/source/dmnt2_transport_session.cpp
+++ b/stratosphere/dmnt.gen2/source/dmnt2_transport_session.cpp
@@ -14,12 +14,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include <stratosphere.hpp>
-#include "dmnt2_htcs_session.hpp"
+#include "dmnt2_transport_layer.hpp"
+#include "dmnt2_transport_session.hpp"
 #include "dmnt2_debug_log.hpp"
 
 namespace ams::dmnt {
 
-    HtcsSession::HtcsSession(int fd) : m_socket(fd), m_valid(true) {
+    TransportSession::TransportSession(int fd) : m_socket(fd), m_valid(true) {
         /* Create our thread. */
         R_ABORT_UNLESS(os::CreateThread(std::addressof(m_receive_thread), ReceiveThreadEntry, this, m_receive_thread_stack, sizeof(m_receive_thread_stack), os::HighestThreadPriority - 1));
 
@@ -30,7 +31,7 @@ namespace ams::dmnt {
         AMS_DMNT2_GDB_LOG_INFO("Created Session %d\n", m_socket);
     }
 
-    HtcsSession::~HtcsSession() {
+    TransportSession::~TransportSession() {
         /* Note that we connected. */
         AMS_DMNT2_GDB_LOG_INFO("Closing Session %d\n", m_socket);
 
@@ -38,25 +39,25 @@ namespace ams::dmnt {
         m_receive_buffer.Invalidate();
 
         /* Shutdown our socket. */
-        htcs::Shutdown(m_socket, htcs::HTCS_SHUT_RDWR);
+        transport::Shutdown(m_socket);
 
         /* Wait for our thread. */
         os::WaitThread(std::addressof(m_receive_thread));
         os::DestroyThread(std::addressof(m_receive_thread));
 
         /* Close our socket. */
-        htcs::Close(m_socket);
+        transport::Close(m_socket);
     }
 
-    bool HtcsSession::WaitToBeReadable() {
+    bool TransportSession::WaitToBeReadable() {
         return m_receive_buffer.WaitToBeReadable();
     }
 
-    bool HtcsSession::WaitToBeReadable(TimeSpan timeout) {
+    bool TransportSession::WaitToBeReadable(TimeSpan timeout) {
         return m_receive_buffer.WaitToBeReadable(timeout);
     }
 
-    util::optional<char> HtcsSession::GetChar() {
+    util::optional<char> TransportSession::GetChar() {
         /* Wait for us to have data. */
         m_receive_buffer.WaitToBeReadable();
 
@@ -69,9 +70,9 @@ namespace ams::dmnt {
         }
     }
 
-    ssize_t HtcsSession::PutChar(char c) {
+    ssize_t TransportSession::PutChar(char c) {
         /* Send the character. */
-        const auto sent = htcs::Send(m_socket, std::addressof(c), sizeof(c), 0);
+        const auto sent = transport::Send(m_socket, std::addressof(c), sizeof(c), 0);
         if (sent < 0) {
             m_valid = false;
         }
@@ -79,13 +80,13 @@ namespace ams::dmnt {
         return sent;
     }
 
-    ssize_t HtcsSession::PutString(const char *str) {
+    ssize_t TransportSession::PutString(const char *str) {
         /* Repeatedly send until all is sent. */
         const size_t len = std::strlen(str);
 
         size_t remaining = len;
         while (remaining > 0) {
-            const auto sent = htcs::Send(m_socket, str, remaining, 0);
+            const auto sent = transport::Send(m_socket, str, remaining, 0);
             if (sent >= 0) {
                 remaining -= sent;
                 str += sent;
@@ -98,22 +99,22 @@ namespace ams::dmnt {
         return len;
     }
 
-    void HtcsSession::ReceiveThreadFunction() {
+    void TransportSession::ReceiveThreadFunction() {
         /* Create temporary buffer. */
-        u8 buffer[HtcsReceiveBuffer::ReceiveBufferSize];
+        u8 buffer[TransportReceiveBuffer::ReceiveBufferSize];
 
         /* Loop receiving data. */
         while (true) {
             /* Receive data. */
-            const auto res = htcs::Recv(m_socket, buffer, sizeof(buffer), 0);
+            const auto res = transport::Recv(m_socket, buffer, sizeof(buffer), 0);
             if (res > 0) {
                 /* Write the data to our buffer. */
                 m_receive_buffer.WaitToBeWritable();
                 m_receive_buffer.Write(buffer, res);
             } else {
                 /* Otherwise, if we got an error other than "try again", we're done. */
-                if (htcs::GetLastError() != htcs::HTCS_EAGAIN) {
-                    AMS_DMNT2_GDB_LOG_INFO("Session %d invalid, res=%ld, err=%d\n", m_socket, res, static_cast<int>(htcs::GetLastError()));
+                if (!transport::IsLastErrorEAgain()) {
+                    AMS_DMNT2_GDB_LOG_INFO("Session %d invalid, res=%ld, err=%d\n", m_socket, res, static_cast<int>(transport::GetLastError()));
                     m_valid = false;
                     break;
                 }

--- a/stratosphere/dmnt.gen2/source/dmnt2_transport_session.hpp
+++ b/stratosphere/dmnt.gen2/source/dmnt2_transport_session.hpp
@@ -15,20 +15,20 @@
  */
 #pragma once
 #include <stratosphere.hpp>
-#include "dmnt2_htcs_receive_buffer.hpp"
+#include "dmnt2_transport_receive_buffer.hpp"
 
 namespace ams::dmnt {
 
-    class HtcsSession {
+    class TransportSession {
         private:
-            alignas(os::ThreadStackAlignment) u8 m_receive_thread_stack[util::AlignUp(os::MemoryPageSize + HtcsReceiveBuffer::ReceiveBufferSize, os::ThreadStackAlignment)];
-            HtcsReceiveBuffer m_receive_buffer;
+            alignas(os::ThreadStackAlignment) u8 m_receive_thread_stack[util::AlignUp(os::MemoryPageSize + TransportReceiveBuffer::ReceiveBufferSize, os::ThreadStackAlignment)];
+            TransportReceiveBuffer m_receive_buffer;
             os::ThreadType m_receive_thread;
             int m_socket;
             bool m_valid;
         public:
-            HtcsSession(int fd);
-            ~HtcsSession();
+            TransportSession(int fd);
+            ~TransportSession();
 
             ALWAYS_INLINE bool IsValid() const { return m_valid; }
 
@@ -41,7 +41,7 @@ namespace ams::dmnt {
 
         private:
             static void ReceiveThreadEntry(void *arg) {
-                static_cast<HtcsSession *>(arg)->ReceiveThreadFunction();
+                static_cast<TransportSession *>(arg)->ReceiveThreadFunction();
             }
 
             void ReceiveThreadFunction();

--- a/stratosphere/dmnt/source/cheat/impl/dmnt_cheat_api.cpp
+++ b/stratosphere/dmnt/source/cheat/impl/dmnt_cheat_api.cpp
@@ -248,7 +248,6 @@ namespace ams::dmnt::cheat::impl {
                 void StartProcess(os::ProcessId process_id) const {
                     R_ABORT_UNLESS(pm::dmnt::StartProcess(process_id));
                 }
-
             public:
                 CheatProcessManager() : m_cheat_lock(), m_unsafe_break_event(os::EventClearMode_ManualClear), m_debug_events_event(os::EventClearMode_AutoClear), m_cheat_process_event(os::EventClearMode_AutoClear, true) {
                     /* Learn whether we should enable cheats by default. */


### PR DESCRIPTION
This adds experimental support for standalone gdbstub (dmnt.gen2), by setting `atmosphere!enable_standalone_gdbstub = u8!0x1` with enable_htc as u8!0x0.

This hosts atmosphere's gdbstub as a standard socket on port 22225.

I'm thinking it makes sense to merge this and include it in releases (certainly until starlink is readily available/usable), but it would be nice to have a higher degree of certainty that our gdbstub is featureful and useful for people's use cases.

single-step/watchpoints should both be functional.

Notable comments:
* While this is enabled, cheats won't work, because the cheat engine is not yet integrated into dmnt.gen2. This is a TODO, it's hard to cleanly integrate because the cheat engine code is pretty terrible in many ways.
* Determining memory layout needs some work. Not sure what stub command we need to add to make this nice and easy? 
* I think loading symbols from PC/ELF doesn't work quite right, not 100% sure what needs to be done for this either.
* I am interested in custom gdb remote commands to e.g. allow auto-attaching to next application or to next homebrew NRO or to specific program ID.