### PR TITLE
Fix GDB monitor unknown command error

### DIFF
--- a/stratosphere/dmnt.gen2/source/dmnt2_gdb_server_impl.cpp
+++ b/stratosphere/dmnt.gen2/source/dmnt2_gdb_server_impl.cpp
@@ -2061,7 +2061,7 @@ namespace ams::dmnt {
             SetReply(m_buffer, "[TODO] wait for program id 0x%lx\n", program_id);
         } else {
             SetReply(m_reply_packet, "Unknown command `%s`\n", command);
-            std::memcpy(m_buffer, m_reply_packet, std::strlen(m_reply_packet));
+            std::memcpy(m_buffer, m_reply_packet, std::strlen(m_reply_packet) + 1);
         }
     }
 


### PR DESCRIPTION
Currently if you enter an unknown command it can also output spurious content afterwards due to not copying the null terminator:
```
(gdb) monitor help
get info
get mappings
get mapping {address}
wait application
wait {program id}
wait homebrew
(gdb) monitor mappings
Unknown command `mappings`
apping {address}
wait application
wait {program id}
wait homebrew
```