### PR TITLE
Minor header fixes to reduce parsing issues with Clang

### DIFF
--- a/libraries/libmesosphere/source/board/nintendo/nx/kern_k_device_page_table.cpp
+++ b/libraries/libmesosphere/source/board/nintendo/nx/kern_k_device_page_table.cpp
@@ -548,11 +548,11 @@ namespace ams::kern::board::nintendo::nx {
 
                         /* Print the interrupt. */
                         {
-                            constexpr auto GetBits = [] ALWAYS_INLINE_LAMBDA (u32 value, size_t ofs, size_t count) {
+                            constexpr auto GetBits = [](u32 value, size_t ofs, size_t count) ALWAYS_INLINE_LAMBDA {
                                 return (value >> ofs) & ((1u << count) - 1);
                             };
 
-                            constexpr auto GetBit = [GetBits] ALWAYS_INLINE_LAMBDA (u32 value, size_t ofs) {
+                            constexpr auto GetBit = [GetBits](u32 value, size_t ofs) ALWAYS_INLINE_LAMBDA {
                                 return (value >> ofs) & 1u;
                             };
 

--- a/libraries/libmesosphere/source/board/nintendo/nx/kern_k_system_control.cpp
+++ b/libraries/libmesosphere/source/board/nintendo/nx/kern_k_system_control.cpp
@@ -312,7 +312,7 @@ namespace ams::kern::board::nintendo::nx {
 
     size_t KSystemControl::Init::GetApplicationPoolSize() {
         /* Get the base pool size. */
-        const size_t base_pool_size = [] ALWAYS_INLINE_LAMBDA () -> size_t {
+        const size_t base_pool_size = []() ALWAYS_INLINE_LAMBDA -> size_t {
             switch (GetMemoryArrangeForInit()) {
                 case smc::MemoryArrangement_4GB:
                 default:
@@ -336,7 +336,7 @@ namespace ams::kern::board::nintendo::nx {
 
     size_t KSystemControl::Init::GetAppletPoolSize() {
         /* Get the base pool size. */
-        const size_t base_pool_size = [] ALWAYS_INLINE_LAMBDA () -> size_t {
+        const size_t base_pool_size = []() ALWAYS_INLINE_LAMBDA -> size_t {
             switch (GetMemoryArrangeForInit()) {
                 case smc::MemoryArrangement_4GB:
                 default:
@@ -490,7 +490,7 @@ namespace ams::kern::board::nintendo::nx {
 
 
         if (AMS_LIKELY(s_initialized_random_generator)) {
-            return KSystemControlBase::GenerateUniformRange(min, max, [] ALWAYS_INLINE_LAMBDA () -> u64 { return s_random_generator.GenerateRandomU64(); });
+            return KSystemControlBase::GenerateUniformRange(min, max, []() ALWAYS_INLINE_LAMBDA -> u64 { return s_random_generator.GenerateRandomU64(); });
         } else {
             return KSystemControlBase::GenerateUniformRange(min, max, GenerateRandomU64FromSmc);
         }

--- a/libraries/libmesosphere/source/kern_k_memory_layout.board.nintendo_nx.cpp
+++ b/libraries/libmesosphere/source/kern_k_memory_layout.board.nintendo_nx.cpp
@@ -195,7 +195,7 @@ namespace ams::kern {
                 static_assert(KMemoryManager::Pool_Secure == KMemoryManager::Pool_System);
 
                 /* Get Secure pool size. */
-                const size_t secure_pool_size = [] ALWAYS_INLINE_LAMBDA (auto target_firmware) -> size_t {
+                const size_t secure_pool_size = [](auto target_firmware) ALWAYS_INLINE_LAMBDA -> size_t {
                     constexpr size_t LegacySecureKernelSize = 8_MB;          /* KPageBuffer pages, other small kernel allocations. */
                     constexpr size_t LegacySecureMiscSize   = 1_MB;          /* Miscellaneous pages for secure process mapping. */
                     constexpr size_t LegacySecureHeapSize   = 24_MB;         /* Heap pages for secure process mapping (fs). */

--- a/libraries/libmesosphere/source/kern_k_page_table_base.cpp
+++ b/libraries/libmesosphere/source/kern_k_page_table_base.cpp
@@ -2398,7 +2398,7 @@ namespace ams::kern {
         size_t cur_size = next_entry.block_size - (GetInteger(cur_addr) & (next_entry.block_size - 1));
         size_t tot_size = cur_size;
 
-        auto PerformCopy = [&] ALWAYS_INLINE_LAMBDA () -> Result {
+        auto PerformCopy = [&]() ALWAYS_INLINE_LAMBDA -> Result {
             /* Ensure the address is linear mapped. */
             R_UNLESS(IsLinearMappedPhysicalAddress(cur_addr), svc::ResultInvalidCurrentMemory());
 
@@ -2484,7 +2484,7 @@ namespace ams::kern {
         size_t cur_size = next_entry.block_size - (GetInteger(cur_addr) & (next_entry.block_size - 1));
         size_t tot_size = cur_size;
 
-        auto PerformCopy = [&] ALWAYS_INLINE_LAMBDA () -> Result {
+        auto PerformCopy = [&]() ALWAYS_INLINE_LAMBDA -> Result {
             /* Ensure the address is linear mapped. */
             R_UNLESS(IsLinearMappedPhysicalAddress(cur_addr), svc::ResultInvalidCurrentMemory());
 
@@ -2943,7 +2943,7 @@ namespace ams::kern {
             size_t cur_size = next_entry.block_size - (GetInteger(cur_addr) & (next_entry.block_size - 1));
             size_t tot_size = cur_size;
 
-            auto PerformCopy = [&] ALWAYS_INLINE_LAMBDA () -> Result {
+            auto PerformCopy = [&]() ALWAYS_INLINE_LAMBDA -> Result {
                 /* Ensure the address is linear mapped. */
                 R_UNLESS(IsLinearMappedPhysicalAddress(cur_addr), svc::ResultInvalidCurrentMemory());
 
@@ -3023,7 +3023,7 @@ namespace ams::kern {
             size_t cur_size = next_entry.block_size - (GetInteger(cur_addr) & (next_entry.block_size - 1));
             size_t tot_size = cur_size;
 
-            auto PerformCopy = [&] ALWAYS_INLINE_LAMBDA () -> Result {
+            auto PerformCopy = [&]() ALWAYS_INLINE_LAMBDA -> Result {
                 /* Ensure the address is linear mapped. */
                 R_UNLESS(IsLinearMappedPhysicalAddress(cur_addr), svc::ResultInvalidCurrentMemory());
 
@@ -3092,7 +3092,7 @@ namespace ams::kern {
             size_t cur_size = next_entry.block_size - (GetInteger(cur_addr) & (next_entry.block_size - 1));
             size_t tot_size = cur_size;
 
-            auto PerformCopy = [&] ALWAYS_INLINE_LAMBDA () -> Result {
+            auto PerformCopy = [&]() ALWAYS_INLINE_LAMBDA -> Result {
                 /* Ensure the address is linear mapped. */
                 R_UNLESS(IsLinearMappedPhysicalAddress(cur_addr), svc::ResultInvalidCurrentMemory());
 
@@ -3172,7 +3172,7 @@ namespace ams::kern {
             size_t cur_size = next_entry.block_size - (GetInteger(cur_addr) & (next_entry.block_size - 1));
             size_t tot_size = cur_size;
 
-            auto PerformCopy = [&] ALWAYS_INLINE_LAMBDA () -> Result {
+            auto PerformCopy = [&]() ALWAYS_INLINE_LAMBDA -> Result {
                 /* Ensure the address is linear mapped. */
                 R_UNLESS(IsLinearMappedPhysicalAddress(cur_addr), svc::ResultInvalidCurrentMemory());
 

--- a/libraries/libmesosphere/source/kern_k_system_control_base.cpp
+++ b/libraries/libmesosphere/source/kern_k_system_control_base.cpp
@@ -96,7 +96,7 @@ namespace ams::kern {
             s_initialized_random_generator = true;
         }
 
-        return KSystemControlBase::GenerateUniformRange(min, max, [] ALWAYS_INLINE_LAMBDA () -> u64 { return s_random_generator.GenerateRandomU64(); });
+        return KSystemControlBase::GenerateUniformRange(min, max, []() ALWAYS_INLINE_LAMBDA -> u64 { return s_random_generator.GenerateRandomU64(); });
     }
 
     /* System Initialization. */
@@ -194,7 +194,7 @@ namespace ams::kern {
         KScopedInterruptDisable intr_disable;
         KScopedSpinLock lk(s_random_lock);
 
-        return KSystemControlBase::GenerateUniformRange(min, max, [] ALWAYS_INLINE_LAMBDA () -> u64 { return s_random_generator.GenerateRandomU64(); });
+        return KSystemControlBase::GenerateUniformRange(min, max, []() ALWAYS_INLINE_LAMBDA -> u64 { return s_random_generator.GenerateRandomU64(); });
     }
 
     u64 KSystemControlBase::GenerateRandomU64() {

--- a/libraries/libmesosphere/source/kern_k_thread.cpp
+++ b/libraries/libmesosphere/source/kern_k_thread.cpp
@@ -1183,7 +1183,7 @@ namespace ams::kern {
         KScopedSchedulerLock sl;
 
         /* Determine if this is the first termination request. */
-        const bool first_request = [&] ALWAYS_INLINE_LAMBDA () -> bool {
+        const bool first_request = [&]() ALWAYS_INLINE_LAMBDA -> bool {
             /* Perform an atomic compare-and-swap from false to true. */
             bool expected = false;
             return m_termination_requested.CompareExchangeStrong(expected, true);

--- a/libraries/libmesosphere/source/svc/kern_svc_address_translation.cpp
+++ b/libraries/libmesosphere/source/svc/kern_svc_address_translation.cpp
@@ -48,7 +48,7 @@ namespace ams::kern::svc {
             /* Check whether the address is aligned. */
             const bool aligned = util::IsAligned(phys_addr, PageSize);
 
-            auto QueryIoMappingFromPageTable = [&] ALWAYS_INLINE_LAMBDA (uint64_t phys_addr, size_t size) -> Result {
+            auto QueryIoMappingFromPageTable = [&](uint64_t phys_addr, size_t size) ALWAYS_INLINE_LAMBDA -> Result {
                 /* The size must be non-zero. */
                 R_UNLESS(size > 0, svc::ResultInvalidSize());
 

--- a/libraries/libmesosphere/source/svc/kern_svc_process.cpp
+++ b/libraries/libmesosphere/source/svc/kern_svc_process.cpp
@@ -210,7 +210,7 @@ namespace ams::kern::svc {
             KResourceLimit *process_resource_limit = resource_limit.IsNotNull() ? resource_limit.GetPointerUnsafe() : std::addressof(Kernel::GetSystemResourceLimit());
 
             /* Get the pool for the process. */
-            const auto pool = [] ALWAYS_INLINE_LAMBDA (u32 flags) -> KMemoryManager::Pool {
+            const auto pool = [](u32 flags) ALWAYS_INLINE_LAMBDA -> KMemoryManager::Pool {
                 if (GetTargetFirmware() >= TargetFirmware_5_0_0) {
                     switch (flags & ams::svc::CreateProcessFlag_PoolPartitionMask) {
                         case ams::svc::CreateProcessFlag_PoolPartitionApplication:

--- a/libraries/libstratosphere/include/stratosphere/settings/settings_types.hpp
+++ b/libraries/libstratosphere/include/stratosphere/settings/settings_types.hpp
@@ -62,16 +62,12 @@ namespace ams::settings {
 
         char name[MaxLength];
 
-        static constexpr LanguageCode Encode(const char *name, size_t name_size) {
+        static constexpr LanguageCode Encode(util::string_view name) {
             LanguageCode out{};
-            for (size_t i = 0; i < MaxLength && i < name_size; i++) {
+            for (size_t i = 0; i < MaxLength && i < name.size(); i++) {
                 out.name[i] = name[i];
             }
             return out;
-        }
-
-        static constexpr LanguageCode Encode(const char *name) {
-            return Encode(name, std::strlen(name));
         }
 
         template<Language Lang>

--- a/libraries/libstratosphere/include/stratosphere/settings/settings_types.hpp
+++ b/libraries/libstratosphere/include/stratosphere/settings/settings_types.hpp
@@ -71,7 +71,7 @@ namespace ams::settings {
         }
 
         template<Language Lang>
-        static constexpr inline LanguageCode EncodeLanguage = [] {
+        static constexpr inline LanguageCode EncodeLanguage() {
             if constexpr (false) { /* ... */ }
             #define AMS_MATCH_LANGUAGE(lang, enc) else if constexpr (Lang == Language_##lang) { return LanguageCode::Encode(enc); }
             AMS_MATCH_LANGUAGE(Japanese,                "ja")
@@ -94,28 +94,28 @@ namespace ams::settings {
             AMS_MATCH_LANGUAGE(TraditionalChinese,      "zh-Hant")
             #undef AMS_MATCH_LANGUAGE
             else { static_assert(Lang != Language_Japanese); }
-        }();
+        }
 
         static constexpr inline LanguageCode Encode(const Language language) {
             constexpr LanguageCode EncodedLanguages[Language_Count] = {
-                EncodeLanguage<Language_Japanese>,
-                EncodeLanguage<Language_AmericanEnglish>,
-                EncodeLanguage<Language_French>,
-                EncodeLanguage<Language_German>,
-                EncodeLanguage<Language_Italian>,
-                EncodeLanguage<Language_Spanish>,
-                EncodeLanguage<Language_Chinese>,
-                EncodeLanguage<Language_Korean>,
-                EncodeLanguage<Language_Dutch>,
-                EncodeLanguage<Language_Portuguese>,
-                EncodeLanguage<Language_Russian>,
-                EncodeLanguage<Language_Taiwanese>,
-                EncodeLanguage<Language_BritishEnglish>,
-                EncodeLanguage<Language_CanadianFrench>,
-                EncodeLanguage<Language_LatinAmericanSpanish>,
+                EncodeLanguage<Language_Japanese>(),
+                EncodeLanguage<Language_AmericanEnglish>(),
+                EncodeLanguage<Language_French>(),
+                EncodeLanguage<Language_German>(),
+                EncodeLanguage<Language_Italian>(),
+                EncodeLanguage<Language_Spanish>(),
+                EncodeLanguage<Language_Chinese>(),
+                EncodeLanguage<Language_Korean>(),
+                EncodeLanguage<Language_Dutch>(),
+                EncodeLanguage<Language_Portuguese>(),
+                EncodeLanguage<Language_Russian>(),
+                EncodeLanguage<Language_Taiwanese>(),
+                EncodeLanguage<Language_BritishEnglish>(),
+                EncodeLanguage<Language_CanadianFrench>(),
+                EncodeLanguage<Language_LatinAmericanSpanish>(),
                 /* 4.0.0+ */
-                EncodeLanguage<Language_SimplifiedChinese>,
-                EncodeLanguage<Language_TraditionalChinese>,
+                EncodeLanguage<Language_SimplifiedChinese>(),
+                EncodeLanguage<Language_TraditionalChinese>(),
             };
             return EncodedLanguages[language];
         }

--- a/libraries/libstratosphere/include/stratosphere/sf/cmif/sf_cmif_domain_manager.hpp
+++ b/libraries/libstratosphere/include/stratosphere/sf/cmif/sf_cmif_domain_manager.hpp
@@ -54,11 +54,11 @@ namespace ams::sf::cmif {
 
                     void DisposeImpl();
 
-                    virtual void AddReference() {
+                    virtual void AddReference() override {
                         ServiceObjectImplBase2::AddReferenceImpl();
                     }
 
-                    virtual void Release() {
+                    virtual void Release() override {
                         if (ServiceObjectImplBase2::ReleaseImpl()) {
                             this->DisposeImpl();
                         }

--- a/libraries/libstratosphere/include/stratosphere/sf/sf_lmem_utility.hpp
+++ b/libraries/libstratosphere/include/stratosphere/sf/sf_lmem_utility.hpp
@@ -43,7 +43,7 @@ namespace ams::sf {
                 return lmem::FreeToExpHeap(m_handle, buffer);
             }
 
-            virtual bool IsEqualImpl(const MemoryResource &resource) const {
+            virtual bool IsEqualImpl(const MemoryResource &resource) const override {
                 return this == std::addressof(resource);
             }
     };
@@ -76,7 +76,7 @@ namespace ams::sf {
                 return lmem::FreeToUnitHeap(m_handle, buffer);
             }
 
-            virtual bool IsEqualImpl(const MemoryResource &resource) const {
+            virtual bool IsEqualImpl(const MemoryResource &resource) const override {
                 return this == std::addressof(resource);
             }
     };

--- a/libraries/libstratosphere/include/stratosphere/sf/sf_mem_utility.hpp
+++ b/libraries/libstratosphere/include/stratosphere/sf/sf_mem_utility.hpp
@@ -37,7 +37,7 @@ namespace ams::sf {
                 return m_standard_allocator->Free(buffer);
             }
 
-            virtual bool IsEqualImpl(const MemoryResource &resource) const {
+            virtual bool IsEqualImpl(const MemoryResource &resource) const override {
                 return this == std::addressof(resource);
             }
     };

--- a/libraries/libstratosphere/include/stratosphere/sf/sf_object_impl_factory.hpp
+++ b/libraries/libstratosphere/include/stratosphere/sf/sf_object_impl_factory.hpp
@@ -31,7 +31,7 @@ namespace ams::sf {
             public:
                 class Object;
                 using Allocator = StatelessDummyAllocator;
-                using StatelessAllocator = typename Policy::StatelessAllocator<Object>;
+                using StatelessAllocator = typename Policy::template StatelessAllocator<Object>;
 
                 class Object final : private ::ams::sf::impl::ServiceObjectImplBase2, public Base {
                     NON_COPYABLE(Object);

--- a/libraries/libstratosphere/include/stratosphere/sm/sm_types.hpp
+++ b/libraries/libstratosphere/include/stratosphere/sm/sm_types.hpp
@@ -40,8 +40,8 @@ namespace ams::sm {
             return out;
         }
 
-        static constexpr ServiceName Encode(const char *name) {
-            return Encode(name, std::strlen(name));
+        static constexpr ServiceName Encode(util::string_view name) {
+            return Encode(name.data(), name.size());
         }
     };
 

--- a/libraries/libstratosphere/include/stratosphere/time/time_calendar_time.hpp
+++ b/libraries/libstratosphere/include/stratosphere/time/time_calendar_time.hpp
@@ -50,7 +50,7 @@ namespace ams::time {
                 AMS_ASSERT(rhs.IsValid());
             }
 
-            constexpr auto ToUint64 = [] ALWAYS_INLINE_LAMBDA (const time::CalendarTime &time) {
+            constexpr auto ToUint64 = [](const time::CalendarTime &time) ALWAYS_INLINE_LAMBDA {
                 return (static_cast<u64>(time.year)   << 40) |
                        (static_cast<u64>(time.month)  << 32) |
                        (static_cast<u64>(time.day)    << 24) |

--- a/libraries/libstratosphere/include/stratosphere/tipc/impl/tipc_impl_command_serialization.hpp
+++ b/libraries/libstratosphere/include/stratosphere/tipc/impl/tipc_impl_command_serialization.hpp
@@ -472,7 +472,7 @@ namespace ams::tipc::impl {
             using OutRawHolderType      = OutRawHolder<CommandMeta::OutDataSize, CommandMeta::OutDataAlign, CommandMeta::OutMessageRawDataIndex>;
             using OutHandleHolderType   = OutHandleHolder<CommandMeta::NumOutMoveHandles, CommandMeta::NumOutCopyHandles, CommandMeta::OutMessageHandleIndex>;
         private:
-            static consteval u64 GetMessageHeaderForCheck(const svc::ipc::MessageBuffer::MessageHeader &header) {
+            static constexpr u64 GetMessageHeaderForCheck(const svc::ipc::MessageBuffer::MessageHeader &header) {
                 using Value = util::BitPack32::Field<0, BITSIZEOF(util::BitPack32)>;
 
                 const util::BitPack32 *data = header.GetData();
@@ -482,7 +482,7 @@ namespace ams::tipc::impl {
                 return static_cast<u64>(lower) | (static_cast<u64>(upper) << BITSIZEOF(u32));
             }
 
-            static consteval u32 GetSpecialHeaderForCheck(const svc::ipc::MessageBuffer::SpecialHeader &header) {
+            static constexpr u32 GetSpecialHeaderForCheck(const svc::ipc::MessageBuffer::SpecialHeader &header) {
                 using Value = util::BitPack32::Field<0, BITSIZEOF(util::BitPack32)>;
 
                 return header.GetHeader()->Get<Value>();

--- a/libraries/libstratosphere/include/stratosphere/tipc/tipc_deferral_manager.hpp
+++ b/libraries/libstratosphere/include/stratosphere/tipc/tipc_deferral_manager.hpp
@@ -167,12 +167,12 @@ namespace ams::tipc {
         return AMS_OFFSETOF(DeferralManagerBase, m_objects_base);
     }
 
-    template<size_t N>
+    template<size_t N> requires (N > 0)
     consteval size_t DeferralManager<N>::GetObjectPointersOffset() {
         return AMS_OFFSETOF(DeferralManager<N>, m_objects);
     }
 
-    template<size_t N>
+    template<size_t N> requires (N > 0)
     inline DeferralManager<N>::DeferralManager() : DeferralManagerBase() {
         static_assert(GetObjectPointersOffset() == GetObjectPointersOffsetBase());
         static_assert(sizeof(DeferralManager<N>) == sizeof(DeferralManagerBase) + N * sizeof(DeferrableBase *));

--- a/libraries/libstratosphere/include/stratosphere/tipc/tipc_server_manager.hpp
+++ b/libraries/libstratosphere/include/stratosphere/tipc/tipc_server_manager.hpp
@@ -747,7 +747,7 @@ namespace ams::tipc {
                 using PortManager = PortManagerImpl;
             private:
                 PortManager m_port_manager;
-                PortInfo::Allocator m_port_allocator;
+                typename PortInfo::Allocator m_port_allocator;
             public:
                 constexpr ServerManagerImpl() : m_port_manager(), m_port_allocator() { /* ... */ }
 

--- a/libraries/libstratosphere/include/stratosphere/tipc/tipc_server_manager.hpp
+++ b/libraries/libstratosphere/include/stratosphere/tipc/tipc_server_manager.hpp
@@ -686,7 +686,7 @@ namespace ams::tipc {
                             }
 
                             /* Try to reply/receive. */
-                            const Result result = [&] ALWAYS_INLINE_LAMBDA () -> Result {
+                            const Result result = [&]() ALWAYS_INLINE_LAMBDA -> Result {
                                 os::MultiWaitHolderType *signaled_holder = nullptr;
                                 ON_SCOPE_EXIT { AMS_ABORT_UNLESS(signaled_holder == nullptr); };
                                 return m_object_manager->ReplyAndReceive(std::addressof(signaled_holder), out_object, reply_target, std::addressof(m_multi_wait));

--- a/libraries/libstratosphere/source/htclow/ctrl/htclow_ctrl_state_machine.cpp
+++ b/libraries/libstratosphere/source/htclow/ctrl/htclow_ctrl_state_machine.cpp
@@ -196,7 +196,7 @@ namespace ams::htclow::ctrl {
         /* Lock ourselves. */
         std::scoped_lock lk(m_mutex);
 
-        auto IsSupportedServiceChannel = [] ALWAYS_INLINE_LAMBDA (const impl::ChannelInternalType &channel, const impl::ChannelInternalType *supported, int num_supported) -> bool {
+        auto IsSupportedServiceChannel = [](const impl::ChannelInternalType &channel, const impl::ChannelInternalType *supported, int num_supported) ALWAYS_INLINE_LAMBDA -> bool {
             for (auto i = 0; i < num_supported; ++i) {
                 if (channel.module_id == supported[i].module_id && channel.channel_id == supported[i].channel_id) {
                     return true;

--- a/libraries/libstratosphere/source/ncm/ncm_content_meta_database_impl.cpp
+++ b/libraries/libstratosphere/source/ncm/ncm_content_meta_database_impl.cpp
@@ -308,7 +308,7 @@ namespace ams::ncm {
             out_orphaned[i] = true;
         }
 
-        auto IsOrphanedContent = [] ALWAYS_INLINE_LAMBDA (const sf::InArray<ContentId> &list, const ncm::ContentId &id) -> util::optional<size_t> {
+        auto IsOrphanedContent = [](const sf::InArray<ContentId> &list, const ncm::ContentId &id) ALWAYS_INLINE_LAMBDA -> util::optional<size_t> {
             /* Check if any input content ids match our found content id. */
             for (size_t i = 0; i < list.GetSize(); i++) {
                 if (list[i] == id) {

--- a/libraries/libvapours/include/vapours/results/results_common.hpp
+++ b/libraries/libvapours/include/vapours/results/results_common.hpp
@@ -177,7 +177,11 @@ namespace ams {
                 static_assert(Value != Base::SuccessValue, "Value != Base::SuccessValue");
             public:
                 constexpr ALWAYS_INLINE operator Result() const { return MakeResult(Value); }
-                constexpr ALWAYS_INLINE operator ResultSuccess() const { OnResultAbort(Value); }
+                constexpr ALWAYS_INLINE operator ResultSuccess() const {
+                    OnResultAbort(Value);
+                    __builtin_unreachable();
+                    return ResultSuccess();
+                }
 
                 constexpr ALWAYS_INLINE bool IsSuccess() const { return false; }
                 constexpr ALWAYS_INLINE bool IsFailure() const { return !this->IsSuccess(); }

--- a/libraries/libvapours/include/vapours/util/util_intrusive_red_black_tree.hpp
+++ b/libraries/libvapours/include/vapours/util/util_intrusive_red_black_tree.hpp
@@ -295,7 +295,7 @@ namespace ams::util {
                 private:
                     constexpr explicit ALWAYS_INLINE Iterator(ImplIterator it) : m_impl(it) { /* ... */ }
 
-                    constexpr explicit ALWAYS_INLINE Iterator(ImplIterator::pointer p) : m_impl(p) { /* ... */ }
+                    constexpr explicit ALWAYS_INLINE Iterator(typename ImplIterator::pointer p) : m_impl(p) { /* ... */ }
 
                     constexpr ALWAYS_INLINE ImplIterator GetImplIterator() const {
                         return m_impl;

--- a/libraries/libvapours/include/vapours/util/util_optional.hpp
+++ b/libraries/libvapours/include/vapours/util/util_optional.hpp
@@ -225,7 +225,7 @@ namespace ams::util {
         template<typename T, typename Derived>
         class OptionalBaseImpl {
             protected:
-                using StoredType = std::remove_const<T>::type;
+                using StoredType = std::remove_const_t<T>;
 
                 template<typename... Args>
                 constexpr void ConstructImpl(Args &&... args) { static_cast<Derived *>(this)->m_payload.Construct(std::forward<Args>(args)...); }

--- a/stratosphere/ams_mitm/source/sysupdater/sysupdater_service.cpp
+++ b/stratosphere/ams_mitm/source/sysupdater/sysupdater_service.cpp
@@ -152,7 +152,7 @@ namespace ams::mitm::sysupdater {
             ON_SCOPE_EXIT { std::free(data_buffer); };
 
             /* Declare helper for result validation. */
-            auto ValidateResult = [&] ALWAYS_INLINE_LAMBDA (Result result) -> Result {
+            auto ValidateResult = [&](Result result) ALWAYS_INLINE_LAMBDA -> Result {
                 *out_result = result;
                 return result;
             };

--- a/stratosphere/sm/source/sm_user_service.hpp
+++ b/stratosphere/sm/source/sm_user_service.hpp
@@ -41,7 +41,7 @@ namespace ams::sm {
 
             Result GetServiceHandle(tipc::OutMoveHandle out_h, ServiceName service) {
                 R_UNLESS(m_initialized, sm::ResultInvalidClient());
-                return this->RegisterRetryIfDeferred(service, [&] ALWAYS_INLINE_LAMBDA () -> Result {
+                return this->RegisterRetryIfDeferred(service, [&]() ALWAYS_INLINE_LAMBDA -> Result {
                     return impl::GetServiceHandle(out_h.GetPointer(), m_process_id, service);
                 });
             }
@@ -66,7 +66,7 @@ namespace ams::sm {
             /* Atmosphere commands. */
             Result AtmosphereInstallMitm(tipc::OutMoveHandle srv_h, tipc::OutMoveHandle qry_h, ServiceName service) {
                 R_UNLESS(m_initialized, sm::ResultInvalidClient());
-                return this->RegisterRetryIfDeferred(service, [&] ALWAYS_INLINE_LAMBDA () -> Result {
+                return this->RegisterRetryIfDeferred(service, [&]() ALWAYS_INLINE_LAMBDA -> Result {
                     return impl::InstallMitm(srv_h.GetPointer(), qry_h.GetPointer(), m_process_id, service);
                 });
             }
@@ -88,7 +88,7 @@ namespace ams::sm {
 
             Result AtmosphereWaitMitm(ServiceName service) {
                 R_UNLESS(m_initialized, sm::ResultInvalidClient());
-                return this->RegisterRetryIfDeferred(service, [&] ALWAYS_INLINE_LAMBDA () -> Result {
+                return this->RegisterRetryIfDeferred(service, [&]() ALWAYS_INLINE_LAMBDA -> Result {
                     return impl::WaitMitm(service);
                 });
             }
@@ -110,7 +110,7 @@ namespace ams::sm {
 
             Result AtmosphereWaitService(ServiceName service) {
                 R_UNLESS(m_initialized, sm::ResultInvalidClient());
-                return this->RegisterRetryIfDeferred(service, [&] ALWAYS_INLINE_LAMBDA () -> Result {
+                return this->RegisterRetryIfDeferred(service, [&]() ALWAYS_INLINE_LAMBDA -> Result {
                     return impl::WaitService(service);
                 });
             }


### PR DESCRIPTION
A small set of fixes to libstratosphere headers to make stratosphere.hpp more parsable by Clang.

At the time of writing Clang has incomplete C++20 support so two of the commits add small, non-intrusive workarounds to allow Clang-based tools to still parse most of stratosphere.hpp and dump type definitions.

Unfortunately getting to 0 compilation errors is not possible at this time because Clang appears to have bugs in its constant evaluation engine and its definition of literal types does not conform to the C++17 standard. (That is the reason why the binary-search based offsetof implementation is broken in some cases on Clang.)

This PR is not just Clang workarounds though, it also fixes some non-standards-compliant code :)