### PR TITLE
Add system setting to mirror bluetooth pairing database to sd card

### DIFF
--- a/config_templates/system_settings.ini
+++ b/config_templates/system_settings.ini
@@ -67,9 +67,8 @@
 ; Note that this setting is ignored (and treated as 1) when htc is enabled.
 ; 0 = Disabled, 1 = Enabled
 ; enable_log_manager = u8!0x0
-; Controls whether the bluetooth pairing database is redirected to sd card for synchronization between sysnand and/or multiple emummcs
-; Note that in firmware 13.0.0 the database size was doubled to 20 entries. Booting to a pre-13.0.0 firmware will cause the
-; database to be truncated to 10 entries.
+; Controls whether the bluetooth pairing database is redirected to the SD card (shared across sysmmc/all emummcs)
+; NOTE: On <13.0.0, the database size was 10 instead of 20; booting pre-13.0.0 will truncate the database.
 ; 0 = Disabled, 1 = Enabled
 ; enable_external_bluetooth_db = u8!0x0
 [hbloader]

--- a/config_templates/system_settings.ini
+++ b/config_templates/system_settings.ini
@@ -67,6 +67,11 @@
 ; Note that this setting is ignored (and treated as 1) when htc is enabled.
 ; 0 = Disabled, 1 = Enabled
 ; enable_log_manager = u8!0x0
+; Controls whether the bluetooth pairing database is redirected to sd card for synchronization between sysnand and/or multiple emummcs
+; Note that in firmware 13.0.0 the database size was doubled to 20 entries. Booting to a pre-13.0.0 firmware will cause the
+; database to be truncated to 10 entries.
+; 0 = Disabled, 1 = Enabled
+; enable_external_bluetooth_db = u8!0x0
 [hbloader]
 ; Controls the size of the homebrew heap when running as applet.
 ; If set to zero, all available applet memory is used as heap.

--- a/libraries/libstratosphere/include/stratosphere/settings/settings_types.hpp
+++ b/libraries/libstratosphere/include/stratosphere/settings/settings_types.hpp
@@ -235,4 +235,34 @@ namespace ams::settings {
         return !(lhs <= rhs);
     }
 
+    struct BluetoothDevicesSettings : public sf::LargeData {
+        u8 address[0x6];
+        char name[0x20];
+        u8 class_of_device[0x3];
+        u8 link_key[0x10];
+        u8 link_key_present;
+        u16 version;
+        u32 trusted_services;
+        u16 vid;
+        u16 pid;
+        u8 sub_class;
+        u8 attribute_mask;
+        u16 descriptor_length;
+        u8 descriptor[0x80];
+        u8 key_type;
+        u8 device_type;
+        u16 brr_size;
+        u8 brr[0x9];
+        union {
+            u8 reserved[0x12B];
+
+            struct {
+                u8 padding;
+                char name2[0xF9];
+            };
+        };
+    };
+
+    static_assert(sizeof(BluetoothDevicesSettings) == sizeof(::SetSysBluetoothDevicesSettings));
+
 }

--- a/libraries/libstratosphere/include/stratosphere/settings/settings_types.hpp
+++ b/libraries/libstratosphere/include/stratosphere/settings/settings_types.hpp
@@ -253,14 +253,9 @@ namespace ams::settings {
         u8 device_type;
         u16 brr_size;
         u8 brr[0x9];
-        union {
-            u8 reserved[0x12B];
-
-            struct {
-                u8 padding;
-                char name2[0xF9];
-            };
-        };
+        u8 reserved0;
+        char name2[0xF9];
+        u8 reserved1[0x31];
     };
 
     static_assert(sizeof(BluetoothDevicesSettings) == sizeof(::SetSysBluetoothDevicesSettings));

--- a/stratosphere/ams_mitm/source/set_mitm/setsys_mitm_service.cpp
+++ b/stratosphere/ams_mitm/source/set_mitm/setsys_mitm_service.cpp
@@ -173,7 +173,7 @@ namespace ams::mitm::settings {
                     /* Increment offset to the next database entry. */
                     db_offset += sizeof(settings::BluetoothDevicesSettings);
                 }
-                fs::FlushFile(file);
+                R_TRY(fs::FlushFile(file));
             } else {
                 R_TRY(fs::WriteFile(file, db_offset, db, total_entries * sizeof(settings::BluetoothDevicesSettings), fs::WriteOption::Flush));
             }

--- a/stratosphere/ams_mitm/source/set_mitm/setsys_mitm_service.cpp
+++ b/stratosphere/ams_mitm/source/set_mitm/setsys_mitm_service.cpp
@@ -137,7 +137,7 @@ namespace ams::mitm::settings {
 
             *entries_read = total_entries;
 
-            return ResultSuccess();
+            R_SUCCEED();
         }
 
         Result StoreExternalBluetoothDatabase(const SetSysBluetoothDevicesSettings *db, size_t total_entries) {
@@ -178,7 +178,7 @@ namespace ams::mitm::settings {
                 R_TRY(fs::WriteFile(file, db_offset, db, total_entries * sizeof(SetSysBluetoothDevicesSettings), fs::WriteOption::Flush));
             }
 
-            return ResultSuccess();
+            R_SUCCEED();
         }
 
     }
@@ -211,7 +211,7 @@ namespace ams::mitm::settings {
         /* Also allow the updated database to be stored to system save as usual. */
         R_TRY(setsysSetBluetoothDevicesSettingsFwd(m_forward_service.get(), settings.GetPointer(), settings.GetSize()));
 
-        return ResultSuccess();
+        R_SUCCEED();
     }
 
     Result SetSysMitmService::GetBluetoothDevicesSettings(sf::Out<s32> out_count, const sf::OutMapAliasArray<SetSysBluetoothDevicesSettings> &out) {
@@ -232,7 +232,7 @@ namespace ams::mitm::settings {
             R_TRY(ReadExternalBluetoothDatabase(out_count.GetPointer(), out.GetPointer(), out.GetSize()));
         }
 
-        return ResultSuccess();
+        R_SUCCEED();
     }
 
     Result SetSysMitmService::GetSettingsItemValueSize(sf::Out<u64> out_size, const settings::SettingsName &name, const settings::SettingsItemKey &key) {

--- a/stratosphere/ams_mitm/source/set_mitm/setsys_mitm_service.cpp
+++ b/stratosphere/ams_mitm/source/set_mitm/setsys_mitm_service.cpp
@@ -114,11 +114,11 @@ namespace ams::mitm::settings {
 
             u64 db_offset = sizeof(total_entries);
             if (total_entries > db_max_size) {
-                /* Cap number of database entries read to size of database on this firmware. */
-                total_entries = db_max_size;
-
                 /* Pairings are stored from least to most recent. Add offset to skip the older entries that won't fit. */
                 db_offset += (total_entries - db_max_size) * sizeof(settings::BluetoothDevicesSettings);
+
+                /* Cap number of database entries read to size of database on this firmware. */
+                total_entries = db_max_size;
             }
 
             /* Read database entries. */

--- a/stratosphere/ams_mitm/source/set_mitm/setsys_mitm_service.hpp
+++ b/stratosphere/ams_mitm/source/set_mitm/setsys_mitm_service.hpp
@@ -16,12 +16,14 @@
 #pragma once
 #include <stratosphere.hpp>
 
-#define AMS_SETTINGS_SYSTEM_MITM_INTERFACE_INFO(C, H)                                                                                                                                                                                               \
-    AMS_SF_METHOD_INFO(C, H,  3, Result, GetFirmwareVersion,       (sf::Out<ams::settings::FirmwareVersion> out),                                                                                                       (out))                      \
-    AMS_SF_METHOD_INFO(C, H,  4, Result, GetFirmwareVersion2,      (sf::Out<ams::settings::FirmwareVersion> out),                                                                                                       (out))                      \
-    AMS_SF_METHOD_INFO(C, H, 37, Result, GetSettingsItemValueSize, (sf::Out<u64> out_size, const ams::settings::SettingsName &name, const ams::settings::SettingsItemKey &key),                           (out_size, name, key))      \
-    AMS_SF_METHOD_INFO(C, H, 38, Result, GetSettingsItemValue,     (sf::Out<u64> out_size, const sf::OutBuffer &out, const ams::settings::SettingsName &name, const ams::settings::SettingsItemKey &key), (out_size, out, name, key)) \
-    AMS_SF_METHOD_INFO(C, H, 62, Result, GetDebugModeFlag,         (sf::Out<bool> out),                                                                                                                                 (out))
+#define AMS_SETTINGS_SYSTEM_MITM_INTERFACE_INFO(C, H)                                                                                                                                                                                    \
+    AMS_SF_METHOD_INFO(C, H,  3, Result, GetFirmwareVersion,          (sf::Out<ams::settings::FirmwareVersion> out),                                                                                         (out))                      \
+    AMS_SF_METHOD_INFO(C, H,  4, Result, GetFirmwareVersion2,         (sf::Out<ams::settings::FirmwareVersion> out),                                                                                         (out))                      \
+    AMS_SF_METHOD_INFO(C, H, 11, Result, SetBluetoothDevicesSettings, (const sf::InMapAliasArray<SetSysBluetoothDevicesSettings> &settings),                                                                 (settings))                 \
+    AMS_SF_METHOD_INFO(C, H, 12, Result, GetBluetoothDevicesSettings, (sf::Out<s32> out_count, const sf::OutMapAliasArray<SetSysBluetoothDevicesSettings> &out),                                             (out_count, out))           \
+    AMS_SF_METHOD_INFO(C, H, 37, Result, GetSettingsItemValueSize,    (sf::Out<u64> out_size, const ams::settings::SettingsName &name, const ams::settings::SettingsItemKey &key),                           (out_size, name, key))      \
+    AMS_SF_METHOD_INFO(C, H, 38, Result, GetSettingsItemValue,        (sf::Out<u64> out_size, const sf::OutBuffer &out, const ams::settings::SettingsName &name, const ams::settings::SettingsItemKey &key), (out_size, out, name, key)) \
+    AMS_SF_METHOD_INFO(C, H, 62, Result, GetDebugModeFlag,            (sf::Out<bool> out),                                                                                                                   (out))
 
 AMS_SF_DEFINE_MITM_INTERFACE(ams::mitm::settings, ISetSysMitmInterface, AMS_SETTINGS_SYSTEM_MITM_INTERFACE_INFO, 0x0E82ED13)
 
@@ -41,6 +43,8 @@ namespace ams::mitm::settings {
         public:
             Result GetFirmwareVersion(sf::Out<ams::settings::FirmwareVersion> out);
             Result GetFirmwareVersion2(sf::Out<ams::settings::FirmwareVersion> out);
+            Result SetBluetoothDevicesSettings(const sf::InMapAliasArray<SetSysBluetoothDevicesSettings> &settings);
+            Result GetBluetoothDevicesSettings(sf::Out<s32> out_count, const sf::OutMapAliasArray<SetSysBluetoothDevicesSettings> &out);
             Result GetSettingsItemValueSize(sf::Out<u64> out_size, const ams::settings::SettingsName &name, const ams::settings::SettingsItemKey &key);
             Result GetSettingsItemValue(sf::Out<u64> out_size, const sf::OutBuffer &out, const ams::settings::SettingsName &name, const ams::settings::SettingsItemKey &key);
             Result GetDebugModeFlag(sf::Out<bool> out);

--- a/stratosphere/ams_mitm/source/set_mitm/setsys_mitm_service.hpp
+++ b/stratosphere/ams_mitm/source/set_mitm/setsys_mitm_service.hpp
@@ -19,8 +19,8 @@
 #define AMS_SETTINGS_SYSTEM_MITM_INTERFACE_INFO(C, H)                                                                                                                                                                                    \
     AMS_SF_METHOD_INFO(C, H,  3, Result, GetFirmwareVersion,          (sf::Out<ams::settings::FirmwareVersion> out),                                                                                         (out))                      \
     AMS_SF_METHOD_INFO(C, H,  4, Result, GetFirmwareVersion2,         (sf::Out<ams::settings::FirmwareVersion> out),                                                                                         (out))                      \
-    AMS_SF_METHOD_INFO(C, H, 11, Result, SetBluetoothDevicesSettings, (const sf::InMapAliasArray<SetSysBluetoothDevicesSettings> &settings),                                                                 (settings))                 \
-    AMS_SF_METHOD_INFO(C, H, 12, Result, GetBluetoothDevicesSettings, (sf::Out<s32> out_count, const sf::OutMapAliasArray<SetSysBluetoothDevicesSettings> &out),                                             (out_count, out))           \
+    AMS_SF_METHOD_INFO(C, H, 11, Result, SetBluetoothDevicesSettings, (const sf::InMapAliasArray<ams::settings::BluetoothDevicesSettings> &settings),                                                                 (settings))                 \
+    AMS_SF_METHOD_INFO(C, H, 12, Result, GetBluetoothDevicesSettings, (sf::Out<s32> out_count, const sf::OutMapAliasArray<ams::settings::BluetoothDevicesSettings> &out),                                             (out_count, out))           \
     AMS_SF_METHOD_INFO(C, H, 37, Result, GetSettingsItemValueSize,    (sf::Out<u64> out_size, const ams::settings::SettingsName &name, const ams::settings::SettingsItemKey &key),                           (out_size, name, key))      \
     AMS_SF_METHOD_INFO(C, H, 38, Result, GetSettingsItemValue,        (sf::Out<u64> out_size, const sf::OutBuffer &out, const ams::settings::SettingsName &name, const ams::settings::SettingsItemKey &key), (out_size, out, name, key)) \
     AMS_SF_METHOD_INFO(C, H, 62, Result, GetDebugModeFlag,            (sf::Out<bool> out),                                                                                                                   (out))
@@ -43,8 +43,8 @@ namespace ams::mitm::settings {
         public:
             Result GetFirmwareVersion(sf::Out<ams::settings::FirmwareVersion> out);
             Result GetFirmwareVersion2(sf::Out<ams::settings::FirmwareVersion> out);
-            Result SetBluetoothDevicesSettings(const sf::InMapAliasArray<SetSysBluetoothDevicesSettings> &settings);
-            Result GetBluetoothDevicesSettings(sf::Out<s32> out_count, const sf::OutMapAliasArray<SetSysBluetoothDevicesSettings> &out);
+            Result SetBluetoothDevicesSettings(const sf::InMapAliasArray<ams::settings::BluetoothDevicesSettings> &settings);
+            Result GetBluetoothDevicesSettings(sf::Out<s32> out_count, const sf::OutMapAliasArray<ams::settings::BluetoothDevicesSettings> &out);
             Result GetSettingsItemValueSize(sf::Out<u64> out_size, const ams::settings::SettingsName &name, const ams::settings::SettingsItemKey &key);
             Result GetSettingsItemValue(sf::Out<u64> out_size, const sf::OutBuffer &out, const ams::settings::SettingsName &name, const ams::settings::SettingsItemKey &key);
             Result GetDebugModeFlag(sf::Out<bool> out);

--- a/stratosphere/ams_mitm/source/set_mitm/setsys_shim.c
+++ b/stratosphere/ams_mitm/source/set_mitm/setsys_shim.c
@@ -15,9 +15,16 @@
  */
 #include "setsys_shim.h"
 
+Result setsysSetBluetoothDevicesSettingsFwd(Service *s, const SetSysBluetoothDevicesSettings *settings, s32 count) {
+    return serviceDispatch(s, 11,
+        .buffer_attrs = { SfBufferAttr_HipcMapAlias | SfBufferAttr_In },
+        .buffers = { { settings, count * sizeof(SetSysBluetoothDevicesSettings) } },
+    );
+}
+
 Result setsysGetBluetoothDevicesSettingsFwd(Service *s, s32 *total_out, SetSysBluetoothDevicesSettings *settings, s32 count) {
     return serviceDispatchOut(s, 12, *total_out,
         .buffer_attrs = { SfBufferAttr_HipcMapAlias | SfBufferAttr_Out },
-        .buffers = { { settings, count*sizeof(SetSysBluetoothDevicesSettings) } },
+        .buffers = { { settings, count * sizeof(SetSysBluetoothDevicesSettings) } },
     );
 }

--- a/stratosphere/ams_mitm/source/set_mitm/setsys_shim.c
+++ b/stratosphere/ams_mitm/source/set_mitm/setsys_shim.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Atmosphère-NX
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "setsys_shim.h"
+
+Result setsysGetBluetoothDevicesSettingsFwd(Service *s, s32 *total_out, SetSysBluetoothDevicesSettings *settings, s32 count) {
+    return serviceDispatchOut(s, 12, *total_out,
+        .buffer_attrs = { SfBufferAttr_HipcMapAlias | SfBufferAttr_Out },
+        .buffers = { { settings, count*sizeof(SetSysBluetoothDevicesSettings) } },
+    );
+}

--- a/stratosphere/ams_mitm/source/set_mitm/setsys_shim.h
+++ b/stratosphere/ams_mitm/source/set_mitm/setsys_shim.h
@@ -12,6 +12,7 @@ extern "C" {
 #endif
 
 /* Forwarding shims. */
+Result setsysSetBluetoothDevicesSettingsFwd(Service *s, const SetSysBluetoothDevicesSettings *settings, s32 count);
 Result setsysGetBluetoothDevicesSettingsFwd(Service *s, s32 *total_out, SetSysBluetoothDevicesSettings *settings, s32 count);
 
 #ifdef __cplusplus

--- a/stratosphere/ams_mitm/source/set_mitm/setsys_shim.h
+++ b/stratosphere/ams_mitm/source/set_mitm/setsys_shim.h
@@ -1,0 +1,19 @@
+/**
+ * @file setsys_shim.h
+ * @brief Settings Services (fs) IPC wrapper for setsys.mitm.
+ * @author ndeadly
+ * @copyright libnx Authors
+ */
+#pragma once
+#include <switch.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Forwarding shims. */
+Result setsysGetBluetoothDevicesSettingsFwd(Service *s, s32 *total_out, SetSysBluetoothDevicesSettings *settings, s32 count);
+
+#ifdef __cplusplus
+}
+#endif

--- a/stratosphere/ams_mitm/source/set_mitm/settings_sd_kvs.cpp
+++ b/stratosphere/ams_mitm/source/set_mitm/settings_sd_kvs.cpp
@@ -393,6 +393,12 @@ namespace ams::settings::fwdbg {
             /* 0 = Disabled, 1 = Enabled */
             R_ABORT_UNLESS(ParseSettingsItemValue("atmosphere", "enable_log_manager", "u8!0x0"));
 
+            /* Controls whether the bluetooth pairing database is redirected to sd card for synchronization between sysnand and/or multiple emummcs. */
+            /* Note that in firmware 13.0.0 the database size was doubled to 20 entries. Booting to a pre-13.0.0 firmware will cause the */
+            /* database to be truncated to 10 entries. */
+            /* 0 = Disabled, 1 = Enabled */
+            R_ABORT_UNLESS(ParseSettingsItemValue("atmosphere", "enable_external_bluetooth_db", "u8!0x0"));
+
             /* Hbloader custom settings. */
 
             /* Controls the size of the homebrew heap when running as applet. */

--- a/stratosphere/ams_mitm/source/set_mitm/settings_sd_kvs.cpp
+++ b/stratosphere/ams_mitm/source/set_mitm/settings_sd_kvs.cpp
@@ -393,9 +393,8 @@ namespace ams::settings::fwdbg {
             /* 0 = Disabled, 1 = Enabled */
             R_ABORT_UNLESS(ParseSettingsItemValue("atmosphere", "enable_log_manager", "u8!0x0"));
 
-            /* Controls whether the bluetooth pairing database is redirected to sd card for synchronization between sysnand and/or multiple emummcs. */
-            /* Note that in firmware 13.0.0 the database size was doubled to 20 entries. Booting to a pre-13.0.0 firmware will cause the */
-            /* database to be truncated to 10 entries. */
+            /* Controls whether the bluetooth pairing database is redirected to the SD card (shared across sysmmc/all emummcs) */
+            /* NOTE: On <13.0.0, the database size was 10 instead of 20; booting pre-13.0.0 will truncate the database. */
             /* 0 = Disabled, 1 = Enabled */
             R_ABORT_UNLESS(ParseSettingsItemValue("atmosphere", "enable_external_bluetooth_db", "u8!0x0"));
 


### PR DESCRIPTION
This adds an opt-in setting to system_settings.ini to enable the console's bluetooth pairing database to be mirrored to a file on the sd card. This facilitates the synchronisation of device pairings between sysnand and/or one or more emummc setups. Paired with Mission Control's bluetooth host address spoofing feature it could even be used to unify device pairings across multiple consoles.

With the release of bluetooth audio support in firmware 13.0.0 the size of the pairing database was doubled from 10 to 20 entries, and the internal layout of fields was changed slightly. We will only store the database in the new format and convert to/from as necessary. Booting a pre-13.0.0 firmware with more than 10 paired devices present in the sd database will cause the database to be truncated to the 10 most recently paired devices.