### PR TITLE
fs: reduce path size 0x28 -> 0x18

### DIFF
--- a/libraries/libstratosphere/include/stratosphere/fs/fs_memory_management.hpp
+++ b/libraries/libstratosphere/include/stratosphere/fs/fs_memory_management.hpp
@@ -18,6 +18,9 @@
 
 namespace ams::fs {
 
+    /* Controls whether MakeUniqueBuffer uses a custom buffer wrapper which wraps the size inline. */
+    #define AMS_FS_IMPL_MAKE_UNIQUE_BUFFER_WITH_INLINE_SIZE
+
     /* ACCURATE_TO_VERSION: Unknown */
     using AllocateFunction   = void *(*)(size_t);
     using DeallocateFunction = void (*)(void *, size_t);
@@ -25,6 +28,8 @@ namespace ams::fs {
     void SetAllocator(AllocateFunction allocator, DeallocateFunction deallocator);
 
     namespace impl {
+
+        class Newable;
 
         void *Allocate(size_t size);
         void Deallocate(void *ptr, size_t size);
@@ -129,21 +134,175 @@ namespace ams::fs {
                 }
         };
 
+        #if defined(AMS_FS_IMPL_MAKE_UNIQUE_BUFFER_WITH_INLINE_SIZE)
+        template<std::convertible_to<u8> BufferEntryType>
+        class BufferWithInlineSize final {
+            static_assert(sizeof(BufferEntryType) == 1);
+            NON_COPYABLE(BufferWithInlineSize);
+            NON_MOVEABLE(BufferWithInlineSize);
+            private:
+                template<std::unsigned_integral T> static constexpr inline T EncodedSizeMask = util::IsLittleEndian() ? (static_cast<T>(3u) << (BITSIZEOF(T) - 2)) : static_cast<T>(3u);
+
+                template<std::unsigned_integral T> static constexpr inline T EncodedSize1    = util::IsLittleEndian() ? (static_cast<T>(0u) << (BITSIZEOF(T) - 2)) : static_cast<T>(0u);
+                template<std::unsigned_integral T> static constexpr inline T EncodedSize2    = util::IsLittleEndian() ? (static_cast<T>(1u) << (BITSIZEOF(T) - 2)) : static_cast<T>(1u);
+                template<std::unsigned_integral T> static constexpr inline T EncodedSize4    = util::IsLittleEndian() ? (static_cast<T>(2u) << (BITSIZEOF(T) - 2)) : static_cast<T>(2u);
+                template<std::unsigned_integral T> static constexpr inline T EncodedSize8    = util::IsLittleEndian() ? (static_cast<T>(3u) << (BITSIZEOF(T) - 2)) : static_cast<T>(3u);
+
+                static constexpr inline u64 TestSize1Mask = ~((static_cast<u64>(1u) << (BITSIZEOF(u8)  - 2)) - static_cast<u64>(1));
+                static constexpr inline u64 TestSize2Mask = ~((static_cast<u64>(1u) << (BITSIZEOF(u16) - 2)) - static_cast<u64>(1));
+                static constexpr inline u64 TestSize4Mask = ~((static_cast<u64>(1u) << (BITSIZEOF(u32) - 2)) - static_cast<u64>(1));
+                static constexpr inline u64 TestSize8Mask = ~((static_cast<u64>(1u) << (BITSIZEOF(u64) - 2)) - static_cast<u64>(1));
+
+                template<std::unsigned_integral SizeType>
+                static constexpr ALWAYS_INLINE SizeType EncodeSize(SizeType type, size_t size) noexcept {
+                    if constexpr (util::IsLittleEndian()) {
+                        return type | static_cast<SizeType>(size);
+                    } else {
+                        return type | (static_cast<SizeType>(size) << 2);
+                    }
+                }
+
+                template<std::unsigned_integral SizeType>
+                static constexpr ALWAYS_INLINE size_t DecodeSize(const SizeType encoded) noexcept {
+                    if constexpr (util::IsLittleEndian()) {
+                        /* Small optimization: 1-byte size has size type field == 0 and no shifting, can return the value directly. */
+                        if constexpr (sizeof(SizeType) == 1) {
+                            static_assert(EncodedSize1<SizeType> == 0);
+                            return encoded;
+                        } else {
+                            /* On little endian, we want to mask out the high bits storing the size field. */
+                            constexpr SizeType DecodedSizeMask = static_cast<SizeType>(~EncodedSizeMask<SizeType>);
+
+                            return encoded & DecodedSizeMask;
+                        }
+                    } else {
+                        /* On big endian, we want to shift out the low bits storing the size type field. */
+                        return encoded >> 2;
+                    }
+                }
+
+                template<std::unsigned_integral SizeType>
+                static ALWAYS_INLINE void DeleteBufferImpl(BufferEntryType *buffer) noexcept {
+                    /* Get pointer to start of allocation. */
+                    SizeType *alloc = reinterpret_cast<SizeType *>(buffer) - 1;
+
+                    /* Decode the size of the allocation. */
+                    const size_t alloc_size = sizeof(SizeType) + DecodeSize<SizeType>(*alloc);
+
+                    /* Delete the buffer. */
+                    return ::ams::fs::impl::Deallocate(alloc, alloc_size);
+                }
+
+                template<std::unsigned_integral SizeType, SizeType EncodedSizeType>
+                static std::unique_ptr<BufferWithInlineSize> MakeBuffer(size_t size) noexcept {
+                    /* Allocate a buffer. */
+                    SizeType *alloc = static_cast<SizeType *>(::ams::fs::impl::Allocate(sizeof(SizeType) + size));
+                    if (AMS_UNLIKELY(alloc == nullptr)) {
+                        return nullptr;
+                    }
+
+                    /* Write the encoded size. */
+                    if constexpr (util::IsLittleEndian()) {
+                        *alloc = EncodedSizeType | static_cast<SizeType>(size);
+                    } else {
+                        *alloc = EncodedSizeType | (static_cast<SizeType>(size) << 2);
+                    }
+
+                    /* Return our buffer. */
+                    return std::unique_ptr<BufferWithInlineSize>(reinterpret_cast<BufferWithInlineSize *>(alloc + 1));
+                }
+
+                static void DeleteBuffer(BufferEntryType *buffer) noexcept {
+                    /* Convert to u8 pointer */
+                    const u8 *buffer_u8 = reinterpret_cast<const u8 *>(buffer);
+
+                    /* Determine the storage size for the size. */
+                    const auto size_type = buffer_u8[-1] & EncodedSizeMask<u8>;
+                    if (size_type == EncodedSize1<u8>) {
+                        return DeleteBufferImpl<u8>(buffer);
+                    } else if (size_type == EncodedSize2<u8>) {
+                        return DeleteBufferImpl<u16>(buffer);
+                    } else if (size_type == EncodedSize4<u8>) {
+                        return DeleteBufferImpl<u32>(buffer);
+                    } else /* if (size_type == EncodedSize8<u8>) */ {
+                        return DeleteBufferImpl<u64>(buffer);
+                    }
+                }
+            private:
+                BufferEntryType m_buffer[1];
+            private:
+                ALWAYS_INLINE BufferWithInlineSize() noexcept { /* ... */ }
+            public:
+                ALWAYS_INLINE ~BufferWithInlineSize() noexcept { /* ... */ }
+            public:
+                ALWAYS_INLINE operator BufferEntryType *() noexcept {
+                    return m_buffer;
+                }
+
+                ALWAYS_INLINE operator const BufferEntryType *() const noexcept {
+                    return m_buffer;
+                }
+            public:
+                static ALWAYS_INLINE std::unique_ptr<BufferWithInlineSize> Make(size_t size) noexcept {
+                    /* Create based on overhead size. */
+                    if (!(size & TestSize1Mask)) {
+                        return MakeBuffer<u8, EncodedSize1<u8>>(size);
+                    } else if (!(size & TestSize2Mask)) {
+                        return MakeBuffer<u16, EncodedSize2<u16>>(size);
+                    } else if (!(size & TestSize4Mask)) {
+                        return MakeBuffer<u32, EncodedSize4<u32>>(size);
+                    } else /* if (!(size & TestSize8Mask)) */ {
+                        /* Check pre-condition. */
+                        AMS_ASSERT(!(size & TestSize8Mask));
+                        return MakeBuffer<u64, EncodedSize8<u64>>(size);
+                    }
+                }
+            public:
+                static ALWAYS_INLINE void *operator new(size_t) noexcept { AMS_ABORT(AMS_CURRENT_FUNCTION_NAME); }
+
+                static ALWAYS_INLINE void *operator new(size_t size, Newable *placement) noexcept { AMS_ABORT(AMS_CURRENT_FUNCTION_NAME); }
+
+                static ALWAYS_INLINE void operator delete(void *ptr, size_t) noexcept {
+                    /* Delete the buffer. */
+                    DeleteBuffer(reinterpret_cast<BufferWithInlineSize *>(ptr)->m_buffer);
+                }
+
+                static void *operator new[](size_t size) noexcept = delete;
+                static void operator delete[](void *ptr, size_t size) noexcept = delete;
+        };
+        #endif
+
         template<typename T>
-        std::unique_ptr<T, Deleter> MakeUnique() {
-            static_assert(util::is_pod<T>::value);
+        auto MakeUnique() {
+            /* Check that we're not using MakeUnique unnecessarily. */
+            static_assert(!std::derived_from<T, ::ams::fs::impl::Newable>);
+
             return std::unique_ptr<T, Deleter>(static_cast<T *>(::ams::fs::impl::Allocate(sizeof(T))), Deleter(sizeof(T)));
         }
 
         template<typename ArrayT>
-        std::unique_ptr<ArrayT, Deleter> MakeUnique(size_t size) {
+        auto MakeUnique(size_t size) {
             using T = typename std::remove_extent<ArrayT>::type;
 
             static_assert(util::is_pod<ArrayT>::value);
             static_assert(std::is_array<ArrayT>::value);
 
+            /* Check that we're not using MakeUnique unnecessarily. */
+            static_assert(!std::derived_from<T, ::ams::fs::impl::Newable>);
+
+            using ReturnType = std::unique_ptr<ArrayT, Deleter>;
+
             const size_t alloc_size = sizeof(T) * size;
-            return std::unique_ptr<ArrayT, Deleter>(static_cast<T *>(::ams::fs::impl::Allocate(alloc_size)), Deleter(alloc_size));
+            return ReturnType(static_cast<T *>(::ams::fs::impl::Allocate(alloc_size)), Deleter(alloc_size));
+        }
+
+        template<typename T>
+        auto MakeUniqueBuffer(size_t size) {
+            #if defined(AMS_FS_IMPL_MAKE_UNIQUE_BUFFER_WITH_INLINE_SIZE)
+            return BufferWithInlineSize<T>::Make(size);
+            #else
+            return ::ams::fs::impl::MakeUnique<T[]>(size);
+            #endif
         }
 
     }

--- a/libraries/libstratosphere/include/stratosphere/fs/fs_memory_management.hpp
+++ b/libraries/libstratosphere/include/stratosphere/fs/fs_memory_management.hpp
@@ -18,9 +18,6 @@
 
 namespace ams::fs {
 
-    /* Controls whether MakeUniqueBuffer uses a custom buffer wrapper which wraps the size inline. */
-    #define AMS_FS_IMPL_MAKE_UNIQUE_BUFFER_WITH_INLINE_SIZE
-
     /* ACCURATE_TO_VERSION: Unknown */
     using AllocateFunction   = void *(*)(size_t);
     using DeallocateFunction = void (*)(void *, size_t);
@@ -134,144 +131,6 @@ namespace ams::fs {
                 }
         };
 
-        #if defined(AMS_FS_IMPL_MAKE_UNIQUE_BUFFER_WITH_INLINE_SIZE)
-        template<std::convertible_to<u8> BufferEntryType>
-        class BufferWithInlineSize final {
-            static_assert(sizeof(BufferEntryType) == 1);
-            NON_COPYABLE(BufferWithInlineSize);
-            NON_MOVEABLE(BufferWithInlineSize);
-            private:
-                template<std::unsigned_integral T> static constexpr inline T EncodedSizeMask = util::IsLittleEndian() ? (static_cast<T>(3u) << (BITSIZEOF(T) - 2)) : static_cast<T>(3u);
-
-                template<std::unsigned_integral T> static constexpr inline T EncodedSize1    = util::IsLittleEndian() ? (static_cast<T>(0u) << (BITSIZEOF(T) - 2)) : static_cast<T>(0u);
-                template<std::unsigned_integral T> static constexpr inline T EncodedSize2    = util::IsLittleEndian() ? (static_cast<T>(1u) << (BITSIZEOF(T) - 2)) : static_cast<T>(1u);
-                template<std::unsigned_integral T> static constexpr inline T EncodedSize4    = util::IsLittleEndian() ? (static_cast<T>(2u) << (BITSIZEOF(T) - 2)) : static_cast<T>(2u);
-                template<std::unsigned_integral T> static constexpr inline T EncodedSize8    = util::IsLittleEndian() ? (static_cast<T>(3u) << (BITSIZEOF(T) - 2)) : static_cast<T>(3u);
-
-                static constexpr inline u64 TestSize1Mask = ~((static_cast<u64>(1u) << (BITSIZEOF(u8)  - 2)) - static_cast<u64>(1));
-                static constexpr inline u64 TestSize2Mask = ~((static_cast<u64>(1u) << (BITSIZEOF(u16) - 2)) - static_cast<u64>(1));
-                static constexpr inline u64 TestSize4Mask = ~((static_cast<u64>(1u) << (BITSIZEOF(u32) - 2)) - static_cast<u64>(1));
-                static constexpr inline u64 TestSize8Mask = ~((static_cast<u64>(1u) << (BITSIZEOF(u64) - 2)) - static_cast<u64>(1));
-
-                template<std::unsigned_integral SizeType>
-                static constexpr ALWAYS_INLINE SizeType EncodeSize(SizeType type, size_t size) noexcept {
-                    if constexpr (util::IsLittleEndian()) {
-                        return type | static_cast<SizeType>(size);
-                    } else {
-                        return type | (static_cast<SizeType>(size) << 2);
-                    }
-                }
-
-                template<std::unsigned_integral SizeType>
-                static constexpr ALWAYS_INLINE size_t DecodeSize(const SizeType encoded) noexcept {
-                    if constexpr (util::IsLittleEndian()) {
-                        /* Small optimization: 1-byte size has size type field == 0 and no shifting, can return the value directly. */
-                        if constexpr (sizeof(SizeType) == 1) {
-                            static_assert(EncodedSize1<SizeType> == 0);
-                            return encoded;
-                        } else {
-                            /* On little endian, we want to mask out the high bits storing the size field. */
-                            constexpr SizeType DecodedSizeMask = static_cast<SizeType>(~EncodedSizeMask<SizeType>);
-
-                            return encoded & DecodedSizeMask;
-                        }
-                    } else {
-                        /* On big endian, we want to shift out the low bits storing the size type field. */
-                        return encoded >> 2;
-                    }
-                }
-
-                template<std::unsigned_integral SizeType>
-                static ALWAYS_INLINE void DeleteBufferImpl(BufferEntryType *buffer) noexcept {
-                    /* Get pointer to start of allocation. */
-                    SizeType *alloc = reinterpret_cast<SizeType *>(buffer) - 1;
-
-                    /* Decode the size of the allocation. */
-                    const size_t alloc_size = sizeof(SizeType) + DecodeSize<SizeType>(*alloc);
-
-                    /* Delete the buffer. */
-                    return ::ams::fs::impl::Deallocate(alloc, alloc_size);
-                }
-
-                template<std::unsigned_integral SizeType, SizeType EncodedSizeType>
-                static std::unique_ptr<BufferWithInlineSize> MakeBuffer(size_t size) noexcept {
-                    /* Allocate a buffer. */
-                    SizeType *alloc = static_cast<SizeType *>(::ams::fs::impl::Allocate(sizeof(SizeType) + size));
-                    if (AMS_UNLIKELY(alloc == nullptr)) {
-                        return nullptr;
-                    }
-
-                    /* Write the encoded size. */
-                    if constexpr (util::IsLittleEndian()) {
-                        *alloc = EncodedSizeType | static_cast<SizeType>(size);
-                    } else {
-                        *alloc = EncodedSizeType | (static_cast<SizeType>(size) << 2);
-                    }
-
-                    /* Return our buffer. */
-                    return std::unique_ptr<BufferWithInlineSize>(reinterpret_cast<BufferWithInlineSize *>(alloc + 1));
-                }
-
-                static void DeleteBuffer(BufferEntryType *buffer) noexcept {
-                    /* Convert to u8 pointer */
-                    const u8 *buffer_u8 = reinterpret_cast<const u8 *>(buffer);
-
-                    /* Determine the storage size for the size. */
-                    const auto size_type = buffer_u8[-1] & EncodedSizeMask<u8>;
-                    if (size_type == EncodedSize1<u8>) {
-                        return DeleteBufferImpl<u8>(buffer);
-                    } else if (size_type == EncodedSize2<u8>) {
-                        return DeleteBufferImpl<u16>(buffer);
-                    } else if (size_type == EncodedSize4<u8>) {
-                        return DeleteBufferImpl<u32>(buffer);
-                    } else /* if (size_type == EncodedSize8<u8>) */ {
-                        return DeleteBufferImpl<u64>(buffer);
-                    }
-                }
-            private:
-                BufferEntryType m_buffer[1];
-            private:
-                ALWAYS_INLINE BufferWithInlineSize() noexcept { /* ... */ }
-            public:
-                ALWAYS_INLINE ~BufferWithInlineSize() noexcept { /* ... */ }
-            public:
-                ALWAYS_INLINE operator BufferEntryType *() noexcept {
-                    return m_buffer;
-                }
-
-                ALWAYS_INLINE operator const BufferEntryType *() const noexcept {
-                    return m_buffer;
-                }
-            public:
-                static ALWAYS_INLINE std::unique_ptr<BufferWithInlineSize> Make(size_t size) noexcept {
-                    /* Create based on overhead size. */
-                    if (!(size & TestSize1Mask)) {
-                        return MakeBuffer<u8, EncodedSize1<u8>>(size);
-                    } else if (!(size & TestSize2Mask)) {
-                        return MakeBuffer<u16, EncodedSize2<u16>>(size);
-                    } else if (!(size & TestSize4Mask)) {
-                        return MakeBuffer<u32, EncodedSize4<u32>>(size);
-                    } else /* if (!(size & TestSize8Mask)) */ {
-                        /* Check pre-condition. */
-                        AMS_ASSERT(!(size & TestSize8Mask));
-                        return MakeBuffer<u64, EncodedSize8<u64>>(size);
-                    }
-                }
-            public:
-                static ALWAYS_INLINE void *operator new(size_t) noexcept { AMS_ABORT(AMS_CURRENT_FUNCTION_NAME); }
-
-                static ALWAYS_INLINE void *operator new(size_t size, Newable *placement) noexcept { AMS_ABORT(AMS_CURRENT_FUNCTION_NAME); }
-
-                static ALWAYS_INLINE void operator delete(void *ptr, size_t) noexcept {
-                    /* Delete the buffer. */
-                    DeleteBuffer(reinterpret_cast<BufferWithInlineSize *>(ptr)->m_buffer);
-                }
-
-                static void *operator new[](size_t size) noexcept = delete;
-                static void operator delete[](void *ptr, size_t size) noexcept = delete;
-        };
-        #endif
-
         template<typename T>
         auto MakeUnique() {
             /* Check that we're not using MakeUnique unnecessarily. */
@@ -294,15 +153,6 @@ namespace ams::fs {
 
             const size_t alloc_size = sizeof(T) * size;
             return ReturnType(static_cast<T *>(::ams::fs::impl::Allocate(alloc_size)), Deleter(alloc_size));
-        }
-
-        template<typename T>
-        auto MakeUniqueBuffer(size_t size) {
-            #if defined(AMS_FS_IMPL_MAKE_UNIQUE_BUFFER_WITH_INLINE_SIZE)
-            return BufferWithInlineSize<T>::Make(size);
-            #else
-            return ::ams::fs::impl::MakeUnique<T[]>(size);
-            #endif
         }
 
     }

--- a/libraries/libstratosphere/include/stratosphere/fs/fs_path.hpp
+++ b/libraries/libstratosphere/include/stratosphere/fs/fs_path.hpp
@@ -62,6 +62,12 @@ namespace ams::fs {
                         return *this;
                     }
 
+                    std::unique_ptr<char[], ::ams::fs::impl::Deleter> ReleaseBuffer() {
+                        auto released = std::unique_ptr<char[], ::ams::fs::impl::Deleter>(m_buffer, ::ams::fs::impl::Deleter(this->GetLength()));
+                        this->ResetBuffer();
+                        return released;
+                    }
+
                     constexpr ALWAYS_INLINE void ResetBuffer() {
                         m_buffer = nullptr;
                         this->SetLength(0);
@@ -118,15 +124,15 @@ namespace ams::fs {
 
             constexpr ~Path() { /* ... */ }
 
-            WriteBuffer ReleaseBuffer() {
+            std::unique_ptr<char[], ::ams::fs::impl::Deleter> ReleaseBuffer() {
                 /* Check pre-conditions. */
                 AMS_ASSERT(m_write_buffer.Get() != nullptr);
 
                 /* Reset. */
                 m_str = EmptyPath;
 
-                /* Return our write buffer. */
-                return std::move(m_write_buffer);
+                /* Release our write buffer. */
+                return m_write_buffer.ReleaseBuffer();
             }
 
             constexpr Result SetShallowBuffer(const char *buffer) {


### PR DESCRIPTION
This implements two optimizations on fs::Path, which N added in 12.0.0.

The current structure looks like: 

```cpp
struct Path {
    const char *m_str; // Points to the read-only path string
    char *m_write_buffer_buffer; // Part of std::unique_ptr<char[], ams::fs::impl::Deleter>
    ams::fs::impl::Deleter m_write_buffer_deleter; // Parse of std::unique_ptr<char[], ams::fs::impl::Deleter>, stores the size of the buffer.
    size_t m_write_buffer_length; // Copy of the write buffer's size accessible to the Path() structure.
    bool m_is_normalized; // Whether the path buffer is normalized
};
```

This is pretty wasteful. The write buffer size is stored twice, wasting 8 bytes, because one copy of the size isn't accessible to the path.

In addition, due to alignment, the bool wastes 7 padding bytes.

This commit:

* Encodes normalized in the low bit of the write buffer length, saving 8 bytes.
* Use a custom WriteBuffer class rather than generic unique_ptr, to avoid needing to store the WriteBuffer twice.


These each save 8 bytes, for a final size of 0x18 rather than 0x28.