### PR TITLE
build: don't choke on stratosphere.hpp.gch file from unclean pre-1.3.0 build dir

### DIFF
--- a/libraries/config/common.mk
+++ b/libraries/config/common.mk
@@ -305,4 +305,5 @@ ATMOSPHERE_GCH_IDENTIFIER := $(ATMOSPHERE_FULL_NAME)
 	$(SILENTCMD)$(CXX) -w -x c++-header -MMD -MP -MQ$@ -MF $(DEPSDIR)/$(notdir $*).d $(CXXFLAGS) -c $< -o $@ $(ERROR_FILTER)
 
 %.hpp.gch: %.hpp
+	@[ -f $@ ] && rm -f $@
 	@[ -d $@ ] || mkdir -p $@


### PR DESCRIPTION
on <=1.2.6 builds, stratosphere.hpp.gch will be a file. The makefile doesn't account for this possibility.

this obviously leads to a failure to mkdir this path