### PR TITLE
KScheduler: fix documentation mistakes

### DIFF
--- a/libraries/libmesosphere/include/mesosphere/kern_k_scheduler.hpp
+++ b/libraries/libmesosphere/include/mesosphere/kern_k_scheduler.hpp
@@ -152,7 +152,7 @@ namespace ams::kern {
             static NOINLINE void OnThreadPriorityChanged(KThread *thread, s32 old_priority);
             static NOINLINE void OnThreadAffinityMaskChanged(KThread *thread, const KAffinityMask &old_affinity, s32 old_core);
 
-            static NOINLINE void RotateScheduledQueue(s32 priority, s32 core_id);
+            static NOINLINE void RotateScheduledQueue(s32 core_id, s32 priority);
 
             static NOINLINE void YieldWithoutCoreMigration();
             static NOINLINE void YieldWithCoreMigration();

--- a/mesosphere/kernel/source/arch/arm64/kern_k_scheduler_asm.s
+++ b/mesosphere/kernel/source/arch/arm64/kern_k_scheduler_asm.s
@@ -219,7 +219,7 @@ _ZN3ams4kern10KScheduler12ScheduleImplEv:
     /* Call ams::kern::KScheduler::SwitchThread(ams::kern::KThread *) */
     bl     _ZN3ams4kern10KScheduler12SwitchThreadEPNS0_7KThreadE
 
-    /* Check if we need scheduling. If we don't, then we can't complete the switch and should retry. */
+    /* Check if we need scheduling. If we do, then we can't complete the switch and should retry. */
     ldarb  w1, [x20] // ldarb w1, [x20, #(KSCHEDULER_NEEDS_SCHEDULING)]
     cbnz   w1, 15f
 


### PR DESCRIPTION
Found these while implementing for yuzu.