### PR TITLE
gdbstub: report architecture tag for ARM targets

### DIFF
--- a/stratosphere/dmnt.gen2/source/dmnt2_gdb_server_impl.cpp
+++ b/stratosphere/dmnt.gen2/source/dmnt2_gdb_server_impl.cpp
@@ -199,6 +199,7 @@ namespace ams::dmnt {
             "l<?xml version=\"1.0\"?>"
             "<!DOCTYPE target SYSTEM \"gdb-target.dtd\">"
             "<target>"
+            "<architecture>arm</architecture>"
             "<xi:include href=\"arm-core.xml\"/>"
             "<xi:include href=\"arm-vfp.xml\"/>"
             "</target>";


### PR DESCRIPTION
Otherwise gdb can't automatically detect the architecture.