### PR TITLE
haze: fix transfers to device becoming larger than intended

### DIFF
--- a/troposphere/haze/include/haze.hpp
+++ b/troposphere/haze/include/haze.hpp
@@ -17,6 +17,7 @@
 
 #include <haze/async_usb_server.hpp>
 #include <haze/common.hpp>
+#include <haze/device_properties.hpp>
 #include <haze/event_reactor.hpp>
 #include <haze/file_system_proxy.hpp>
 #include <haze/ptp.hpp>

--- a/troposphere/haze/include/haze/device_properties.hpp
+++ b/troposphere/haze/include/haze/device_properties.hpp
@@ -13,16 +13,14 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <haze.hpp>
-#include <haze/console_main_loop.hpp>
+#pragma once
 
-int main(int argc, char **argv) {
-    /* Load device firmware version and serial number. */
-    HAZE_R_ABORT_UNLESS(haze::LoadDeviceProperties());
+namespace haze {
 
-    /* Run the application. */
-    haze::ConsoleMainLoop::RunApplication();
+    Result LoadDeviceProperties();
 
-    /* Return to the loader. */
-    return 0;
+    const char *GetSerialNumber();
+
+    const char *GetFirmwareVersion();
+
 }

--- a/troposphere/haze/source/device_properties.cpp
+++ b/troposphere/haze/source/device_properties.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Atmosphère-NX
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <haze.hpp>
+
+namespace haze {
+
+    namespace {
+
+        constinit SetSysSerialNumber g_serial_number = {};
+        constinit SetSysFirmwareVersion g_firmware_version = {};
+
+    }
+
+    Result LoadDeviceProperties() {
+        /* Initialize set:sys. */
+        R_TRY(setsysInitialize());
+
+        /* Ensure we maintain a clean state on exit. */
+        ON_SCOPE_EXIT { setsysExit(); };
+
+        /* Get the serial number and firmware version. */
+        R_TRY(setsysGetSerialNumber(std::addressof(g_serial_number)));
+        R_TRY(setsysGetFirmwareVersion(std::addressof(g_firmware_version)));
+
+        /* We succeeded. */
+        R_SUCCEED();
+    }
+
+    const char *GetSerialNumber() {
+        return g_serial_number.number;
+    }
+
+    const char *GetFirmwareVersion() {
+        return g_firmware_version.display_version;
+    }
+
+}

--- a/troposphere/haze/source/ptp_responder.cpp
+++ b/troposphere/haze/source/ptp_responder.cpp
@@ -722,7 +722,9 @@ namespace haze {
         R_TRY(m_fs.SetFileSize(std::addressof(file), 0));
 
         /* Expand to the needed size. */
-        R_TRY(m_fs.SetFileSize(std::addressof(file), data_header.length));
+        if (data_header.length > sizeof(PtpUsbBulkContainer)) {
+            R_TRY(m_fs.SetFileSize(std::addressof(file), data_header.length - sizeof(PtpUsbBulkContainer)));
+        }
 
         /* Begin writing to the filesystem. */
         while (true) {
@@ -742,6 +744,9 @@ namespace haze {
 
             R_TRY(read_res);
         }
+
+        /* Truncate the file to the received size. */
+        R_TRY(m_fs.SetFileSize(std::addressof(file), offset));
 
         /* Write the success response. */
         R_RETURN(this->WriteResponse(PtpResponseCode_Ok));

--- a/troposphere/haze/source/ptp_responder.cpp
+++ b/troposphere/haze/source/ptp_responder.cpp
@@ -304,16 +304,6 @@ namespace haze {
     Result PtpResponder::GetDeviceInfo(PtpDataParser &dp) {
         PtpDataBuilder db(g_bulk_write_buffer, std::addressof(m_usb_server));
 
-        /* Initialize set:sys, ensuring we clean up on exit. */
-        R_TRY(setsysInitialize());
-        ON_SCOPE_EXIT { setsysExit(); };
-
-        /* Get the device version and serial number. */
-        SetSysFirmwareVersion version;
-        SetSysSerialNumber serial;
-        R_TRY(setsysGetFirmwareVersion(std::addressof(version)));
-        R_TRY(setsysGetSerialNumber(std::addressof(serial)));
-
         /* Write the device info data. */
         R_TRY(db.WriteVariableLengthData(m_request_header, [&] () {
             R_TRY(db.Add(MtpStandardVersion));
@@ -328,8 +318,8 @@ namespace haze {
             R_TRY(db.AddArray(SupportedPlaybackFormats, util::size(SupportedPlaybackFormats)));
             R_TRY(db.AddString(MtpDeviceManufacturer));
             R_TRY(db.AddString(MtpDeviceModel));
-            R_TRY(db.AddString(version.display_version));
-            R_TRY(db.AddString(serial.number));
+            R_TRY(db.AddString(GetFirmwareVersion()));
+            R_TRY(db.AddString(GetSerialNumber()));
 
             R_SUCCEED();
         }));

--- a/troposphere/haze/source/usb_session.cpp
+++ b/troposphere/haze/source/usb_session.cpp
@@ -165,19 +165,11 @@ namespace haze {
             static const u16 supported_langs[1] = { 0x0409 };
             R_TRY(usbDsAddUsbLanguageStringDescriptor(nullptr, supported_langs, util::size(supported_langs)));
 
-            /* Initialize set:sys, ensuring we clean up on exit. */
-            R_TRY(setsysInitialize());
-            ON_SCOPE_EXIT { setsysExit(); };
-
-            /* Get the device serial number. */
-            SetSysSerialNumber serial;
-            R_TRY(setsysGetSerialNumber(std::addressof(serial)));
-
             /* Report strings. */
             u8 iManufacturer, iProduct, iSerialNumber;
             R_TRY(usbDsAddUsbStringDescriptor(std::addressof(iManufacturer), "Nintendo"));
             R_TRY(usbDsAddUsbStringDescriptor(std::addressof(iProduct), "Nintendo Switch"));
-            R_TRY(usbDsAddUsbStringDescriptor(std::addressof(iSerialNumber), serial.number));
+            R_TRY(usbDsAddUsbStringDescriptor(std::addressof(iSerialNumber), GetSerialNumber()));
 
             /* Send device descriptors */
             struct usb_device_descriptor device_descriptor = {


### PR DESCRIPTION
This unintentionally made files transferred to the device 12 bytes larger than they were supposed to be with the "set size in advance" performance optimization, which didn't account for the PTP header. This really obvious issue was unfortunately missed because the optimization was made after I had already tested roundtrips.

Also streamlines getting the device firmware version and serial number as part of a separate change.