### PR TITLE
ams: fix compilation with gcc 13

### DIFF
--- a/libraries/libmesosphere/include/mesosphere/kern_k_auto_object.hpp
+++ b/libraries/libmesosphere/include/mesosphere/kern_k_auto_object.hpp
@@ -257,7 +257,7 @@ namespace ams::kern {
     class KScopedAutoObject {
         NON_COPYABLE(KScopedAutoObject);
         private:
-            template<typename U>
+            template<typename U> requires std::derived_from<U, KAutoObject>
             friend class KScopedAutoObject;
         private:
             T *m_obj;

--- a/libraries/libmesosphere/include/mesosphere/kern_k_typed_address.hpp
+++ b/libraries/libmesosphere/include/mesosphere/kern_k_typed_address.hpp
@@ -120,10 +120,6 @@ namespace ams::kern {
                 return m_address == rhs;
             }
 
-            constexpr ALWAYS_INLINE bool operator!=(uintptr_t rhs) const {
-                return m_address != rhs;
-            }
-
             /* Allow getting the address explicitly, for use in accessors. */
             constexpr ALWAYS_INLINE uintptr_t GetValue() const {
                 return m_address;

--- a/libraries/libmesosphere/include/mesosphere/kern_slab_helpers.hpp
+++ b/libraries/libmesosphere/include/mesosphere/kern_slab_helpers.hpp
@@ -164,8 +164,9 @@ namespace ams::kern {
     };
 
 
-    template<typename Derived, typename Base, bool SupportDynamicExpansion = false> requires std::derived_from<Base, KAutoObjectWithList>
+    template<typename Derived, typename Base, bool SupportDynamicExpansion = false>
     class KAutoObjectWithSlabHeapAndContainer : public KAutoObjectWithSlabHeapBase<Derived, Base, SupportDynamicExpansion> {
+        static_assert(std::derived_from<Base, KAutoObjectWithList>);
         private:
             static constinit inline KAutoObjectWithListContainer<Derived> s_container;
         public:

--- a/libraries/libmesosphere/source/svc/kern_svc_physical_memory.cpp
+++ b/libraries/libmesosphere/source/svc/kern_svc_physical_memory.cpp
@@ -27,7 +27,7 @@ namespace ams::kern::svc {
             R_UNLESS(size < ams::kern::MainMemorySizeMax,                svc::ResultInvalidSize());
 
             /* Set the heap size. */
-            KProcessAddress address;
+            KProcessAddress address = Null<KProcessAddress>;
             R_TRY(GetCurrentProcess().GetPageTable().SetHeapSize(std::addressof(address), size));
 
             /* Set the output. */

--- a/libraries/libstratosphere/source/sf/hipc/sf_hipc_server_domain_session_manager.cpp
+++ b/libraries/libstratosphere/source/sf/hipc/sf_hipc_server_domain_session_manager.cpp
@@ -48,7 +48,7 @@ namespace ams::sf::hipc {
                         AMS_ABORT_UNLESS(ServerManagerBase::CanAnyManageMitmServers());
 
                         /* Clone the forward service. */
-                        std::shared_ptr<::Service> new_forward_service = std::move(ServerSession::CreateForwardService());
+                        std::shared_ptr<::Service> new_forward_service = ServerSession::CreateForwardService();
                         R_ABORT_UNLESS(serviceClone(util::GetReference(m_session->m_forward_service).get(), new_forward_service.get()));
                         R_ABORT_UNLESS(tagged_manager->RegisterMitmSession(server_handle, std::move(clone), std::move(new_forward_service)));
                     }
@@ -168,7 +168,7 @@ namespace ams::sf::hipc {
                         R_ABORT_UNLESS(hipc::CreateSession(std::addressof(server_handle), std::addressof(client_handle)));
 
                         /* Register. */
-                        std::shared_ptr<::Service> new_forward_service = std::move(ServerSession::CreateForwardService());
+                        std::shared_ptr<::Service> new_forward_service = ServerSession::CreateForwardService();
                         serviceCreate(new_forward_service.get(), new_forward_target);
                         R_ABORT_UNLESS(m_manager->RegisterMitmSession(server_handle, std::move(object), std::move(new_forward_service)));
 

--- a/libraries/libvapours/include/vapours/util/util_intrusive_list.hpp
+++ b/libraries/libvapours/include/vapours/util/util_intrusive_list.hpp
@@ -144,10 +144,6 @@ namespace ams::util {
                             return m_node == rhs.m_node;
                         }
 
-                        constexpr ALWAYS_INLINE bool operator!=(const Iterator &rhs) const {
-                            return !(*this == rhs);
-                        }
-
                         constexpr ALWAYS_INLINE pointer operator->() const {
                             return m_node;
                         }
@@ -353,10 +349,6 @@ namespace ams::util {
                 public:
                     constexpr ALWAYS_INLINE bool operator==(const Iterator &rhs) const {
                         return m_iterator == rhs.m_iterator;
-                    }
-
-                    constexpr ALWAYS_INLINE bool operator!=(const Iterator &rhs) const {
-                        return !(*this == rhs);
                     }
 
                     constexpr ALWAYS_INLINE pointer operator->() const {

--- a/libraries/libvapours/include/vapours/util/util_intrusive_red_black_tree.hpp
+++ b/libraries/libvapours/include/vapours/util/util_intrusive_red_black_tree.hpp
@@ -94,10 +94,6 @@ namespace ams::util {
                             return m_node == rhs.m_node;
                         }
 
-                        constexpr ALWAYS_INLINE bool operator!=(const Iterator &rhs) const {
-                            return !(*this == rhs);
-                        }
-
                         constexpr ALWAYS_INLINE pointer operator->() const {
                             return m_node;
                         }
@@ -302,10 +298,6 @@ namespace ams::util {
                 public:
                     constexpr ALWAYS_INLINE bool operator==(const Iterator &rhs) const {
                         return m_impl == rhs.m_impl;
-                    }
-
-                    constexpr ALWAYS_INLINE bool operator!=(const Iterator &rhs) const {
-                        return !(*this == rhs);
                     }
 
                     constexpr ALWAYS_INLINE pointer operator->() const {

--- a/stratosphere/ams_mitm/source/fs_mitm/fsmitm_romfs.cpp
+++ b/stratosphere/ams_mitm/source/fs_mitm/fsmitm_romfs.cpp
@@ -251,12 +251,11 @@ namespace ams::mitm::fs {
             using DirectoryTableWriter = TableWriter<DirectoryEntry>;
             using FileTableWriter      = TableWriter<FileEntry>;
 
-            constexpr inline u32 CalculatePathHash(u32 parent, const char *_path, u32 start, size_t path_len) {
-                const unsigned char *path = reinterpret_cast<const unsigned char *>(_path);
+            constexpr inline u32 CalculatePathHash(u32 parent, const char *path, u32 start, size_t path_len) {
                 u32 hash = parent ^ 123456789;
                 for (size_t i = 0; i < path_len; i++) {
                     hash = (hash >> 5) | (hash << 27);
-                    hash ^= path[start + i];
+                    hash ^= static_cast<unsigned char>(path[start + i]);
                 }
                 return hash;
             }


### PR DESCRIPTION
GCC upgrade breaks on AMS code as usual. Going to open a separate issue to track the romfs issue this causes with Fire Emblem: Engage.