### PR TITLE
Add automated CI builds with GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,64 @@
+---
+name: Build
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  Linux:
+    container:
+      image: devkitpro/devkita64:latest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: |
+          apt-get --yes update
+          apt-get --yes install build-essential python-pip zstd
+
+      - name: Install `python` dependencies
+        run: |
+          pip install lz4 pycryptodome
+
+      - name: Build & Install `hactool`
+        run: |
+          echo 'MAKEFLAGS="-j'$(($(nproc) + 1))'"' >> /opt/devkitpro/pacman/etc/makepkg.conf
+          usermod --home=/home/nobody --root=/home/nobody --shell=/bin/bash nobody
+          mkdir --parents /home/nobody
+          chown nobody:nogroup /home/nobody
+          curl --silent https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=hactool | sudo --user nobody --login tee /home/nobody/PKGBUILD
+          sudo --user nobody --login dkp-makepkg
+          dkp-pacman --upgrade --noconfirm /home/nobody/hactool*.zst
+
+      - name: Ensure GITHUB_WORKSPACE directory is considered safe
+        run: |
+          git config --global --add safe.directory ${GITHUB_WORKSPACE}
+
+      - name: Make
+        run: |
+          make -j$(($(nproc) + 1))
+
+      - name: Move Debug package
+        run: |
+          mv out/nintendo_nx_arm64_armv8a/release/atmosphere*-debug.zip /tmp/
+
+      - name: Upload Fusée
+        uses: actions/upload-artifact@v3
+        with:
+          name: Fusée
+          path: out/nintendo_nx_arm64_armv8a/release/fusee.bin
+
+      - name: Upload Atmosphère Archive
+        uses: actions/upload-artifact@v3
+        with:
+          name: Atmosphère
+          path: out/nintendo_nx_arm64_armv8a/release/atmosphere*.zip
+
+      - name: Upload Atmosphère Archive (Debug)
+        uses: actions/upload-artifact@v3
+        with:
+          name: Atmosphère-Debug
+          path: /tmp/atmosphere*.zip


### PR DESCRIPTION
This pull request adds automated CI builds using GitHub Actions.

I noticed that there were at least two closed pull requests pre-`1.0.0` adding continuous integration builds and since Atmosphère `1.0.0` has been released (which was one of the stipulations of adding continuous integration builds) and no additional pull requests adding continuous integration builds have been created, I decided to give it another try.

Getting this to also build using `Windows` as suggested would be tricky as it seems most (if not all) of the IPs used by GitHub Actions have been banned from using `pkg.devkitpro.org` and devkitPro's recommendation is to just use the docker images they build and upload to `hub.docker.com`. Unfortunately they do not provide a Windows docker image which would likely solve most (if not all) of this issue.

The aforementioned IP banning is the reason why `hactool` is needing to be built here, luckily it only takes about 10-20 seconds.

Feel free to let me know if there are any comments/suggestions or if it would be preferable to just close this pull request.

Thanks and have a nice day!

Here is an example of a successful Workflow run:
https://github.com/hummeltech/Atmosphere/actions/runs/5373884521/jobs/9748692838