### PR TITLE
haze: fix bMaxPacketSize0

### DIFF
--- a/troposphere/haze/source/usb_session.cpp
+++ b/troposphere/haze/source/usb_session.cpp
@@ -191,6 +191,7 @@ namespace haze {
             R_TRY(usbDsSetUsbDeviceDescriptor(UsbDeviceSpeed_High, std::addressof(device_descriptor)));
 
             device_descriptor.bcdUSB = 0x0300;
+            device_descriptor.bMaxPacketSize0 = 0x09;
             R_TRY(usbDsSetUsbDeviceDescriptor(UsbDeviceSpeed_Super, std::addressof(device_descriptor)));
 
             /* Binary Object Store */


### PR DESCRIPTION
I believe this is the source of many reports of haze having issues with USB3, as the only valid bMaxPacketSize0 for superspeed mode is 0x09 (512).