### PR TITLE
exo: Invert quest state.

### DIFF
--- a/libraries/libexosphere/source/fuse/fuse_api.cpp
+++ b/libraries/libexosphere/source/fuse/fuse_api.cpp
@@ -359,7 +359,8 @@ namespace ams::fuse {
     }
 
     RetailInteractiveDisplayState GetRetailInteractiveDisplayState() {
-        return static_cast<RetailInteractiveDisplayState>(util::BitPack32{GetCommonOdmWord(4)}.Get<OdmWord4::RetailInteractiveDisplayState>());
+        /* I do this so I can be incredibly lazy with certain things, please don't kill me :( */
+        return static_cast<RetailInteractiveDisplayState>(!util::BitPack32{GetCommonOdmWord(4)}.Get<OdmWord4::RetailInteractiveDisplayState>());
     }
 
     pmic::Regulator GetRegulator() {


### PR DESCRIPTION
Can you take a look at this?
Seems like it bypass the error that shows upon booting on  demo/kiosk units