### PR TITLE
dmnt.gen2: enable gdbserver QStartNoAckMode

### DIFF
--- a/stratosphere/dmnt.gen2/source/dmnt2_gdb_server_impl.cpp
+++ b/stratosphere/dmnt.gen2/source/dmnt2_gdb_server_impl.cpp
@@ -1538,11 +1538,16 @@ namespace ams::dmnt {
     }
 
     void GdbServerImpl::Q() {
-        if (false) {
-            /* TODO: QStartNoAckMode? */
+        if (ParsePrefix(m_receive_packet, "QStartNoAckMode")) {
+            this->QStartNoAckMode();
         } else {
             AMS_DMNT2_GDB_LOG_DEBUG("Not Implemented Q: %s\n", m_receive_packet);
         }
+    }
+
+    void GdbServerImpl::QStartNoAckMode() {
+        m_packet_io.SetNoAck();
+        AppendReplyOk(m_reply_cur, m_reply_end);
     }
 
     void GdbServerImpl::T() {
@@ -1919,6 +1924,7 @@ namespace ams::dmnt {
         R_SUCCEED();
     }
 
+
     void GdbServerImpl::q() {
         if (ParsePrefix(m_receive_packet, "qAttached:")) {
             this->qAttached();
@@ -2145,6 +2151,7 @@ namespace ams::dmnt {
         AppendReplyFormat(m_reply_cur, m_reply_end, ";swbreak+");
         AppendReplyFormat(m_reply_cur, m_reply_end, ";hwbreak+");
         AppendReplyFormat(m_reply_cur, m_reply_end, ";vContSupported+");
+        AppendReplyFormat(m_reply_cur, m_reply_end, ";QStartNoAckMode+");
     }
 
     void GdbServerImpl::qXfer() {

--- a/stratosphere/dmnt.gen2/source/dmnt2_gdb_server_impl.hpp
+++ b/stratosphere/dmnt.gen2/source/dmnt2_gdb_server_impl.hpp
@@ -77,6 +77,8 @@ namespace ams::dmnt {
 
             void Q();
 
+            void QStartNoAckMode();
+
             void T();
 
             void Z();


### PR DESCRIPTION
Currently the gdb server is only used over a TCP socket. Since TCP is a reliable protocol, retransmission will not be needed. This improves performance a lot even when running over a wired network.