### PR TITLE
dmnt.gen2: avoid data abort when too many breakpoints are created

### DIFF
--- a/stratosphere/dmnt.gen2/source/dmnt2_breakpoint_manager.cpp
+++ b/stratosphere/dmnt.gen2/source/dmnt2_breakpoint_manager.cpp
@@ -45,7 +45,7 @@ namespace ams::dmnt {
         }
 
         if (R_FAILED(result)) {
-            AMS_DMNT2_GDB_LOG_DEBUG("BreakPointManager::SetBreakPoint %p 0x%lx !!! Fail 0x%08x !!!\n", bp, bp->m_address, result.GetValue());
+            AMS_DMNT2_GDB_LOG_DEBUG("BreakPointManager::SetBreakPoint %p 0x%lx !!! Fail 0x%08x !!!\n", bp, address, result.GetValue());
         }
 
         R_RETURN(result);


### PR DESCRIPTION
GetFreeBreakPoint will return nullptr when the number of breakpoints is exhausted. Prevent a null pointer dereference in this case.