### PR TITLE
Fix compilation with GCC 14

### DIFF
--- a/fusee/program/source/sdram/fusee_sdram.cpp
+++ b/fusee/program/source/sdram/fusee_sdram.cpp
@@ -1002,14 +1002,16 @@ namespace ams::nxboot {
                                                                                                \
                         constexpr u32 SrcLow = RANGE_LOW(SRC_RANGE);                           \
                         constexpr u32 DstLow = RANGE_LOW(DST_RANGE);                           \
+                        constexpr auto Shift = (SrcLow < DstLow) ? (DstLow - SrcLow)           \
+                                                                 : (SrcLow - DstLow);          \
                                                                                                \
                         cur_reg_value &= ~Mask;                                                \
                         if constexpr (SrcLow == DstLow) {                                      \
                             cur_reg_value |= (src_value & Mask);                               \
                         } else if constexpr (SrcLow < DstLow) {                                \
-                            cur_reg_value |= ((src_value << (DstLow - SrcLow)) & Mask);        \
+                            cur_reg_value |= ((src_value << Shift) & Mask);                    \
                         } else {                                                               \
-                            cur_reg_value |= ((src_value >> (SrcLow - DstLow)) & Mask);        \
+                            cur_reg_value |= ((src_value >> Shift) & Mask);                    \
                         }                                                                      \
                     }                                                                          \
                 }

--- a/libraries/config/common.mk
+++ b/libraries/config/common.mk
@@ -44,7 +44,7 @@ else ifeq ($(strip $(ATMOSPHERE_COMPILER_NAME)),clang)
 export ATMOSPHERE_CFLAGS += -Wno-c99-designator -Wno-gnu-alignof-expression -Wno-unused-private-field
 endif
 
-export ATMOSPHERE_CXXFLAGS := -fno-rtti -fno-exceptions -std=gnu++20 -Wno-invalid-offsetof
+export ATMOSPHERE_CXXFLAGS := -fno-rtti -fno-exceptions -std=gnu++23 -Wno-invalid-offsetof
 export ATMOSPHERE_ASFLAGS  :=
 
 

--- a/libraries/libstratosphere/source/ams/ams_emummc_api.cpp
+++ b/libraries/libstratosphere/source/ams/ams_emummc_api.cpp
@@ -73,7 +73,7 @@ namespace ams::emummc {
             /* Retrieve and cache values. */
             {
 
-                typename std::aligned_storage<2 * (MaxDirLen + 1), os::MemoryPageSize>::type path_storage;
+                alignas(os::MemoryPageSize) std::byte path_storage[2 * (MaxDirLen + 1)];
 
                 struct {
                     char file_path[MaxDirLen + 1];

--- a/libraries/libstratosphere/source/fs/fs_api.cpp
+++ b/libraries/libstratosphere/source/fs/fs_api.cpp
@@ -23,8 +23,8 @@ namespace ams::fs {
     #if defined(ATMOSPHERE_OS_HORIZON)
     namespace {
 
-        constinit std::aligned_storage_t<0x80> g_fsp_service_object_buffer;
-        constinit std::aligned_storage_t<0x80> g_fsp_ldr_service_object_buffer;
+        alignas(0x10) constinit std::byte g_fsp_service_object_buffer[0x80] = {};
+        alignas(0x10) constinit std::byte g_fsp_ldr_service_object_buffer[0x80] = {};
         constinit bool g_use_static_fsp_service_object_buffer = false;
         constinit bool g_use_static_fsp_ldr_service_object_buffer = false;
 

--- a/libraries/libstratosphere/source/fssrv/impl/fssrv_program_info.cpp
+++ b/libraries/libstratosphere/source/fssrv/impl/fssrv_program_info.cpp
@@ -20,7 +20,7 @@ namespace ams::fssrv::impl {
 
     namespace {
 
-        constinit std::aligned_storage<0x80>::type g_static_buffer_for_program_info_for_initial_process = {};
+        alignas(0x10) constinit std::byte g_static_buffer_for_program_info_for_initial_process[0x80] = {};
 
         template<typename T>
         class StaticAllocatorForProgramInfoForInitialProcess : public std::allocator<T> {

--- a/libraries/libstratosphere/source/htc/server/rpc/htc_rpc_task_table.hpp
+++ b/libraries/libstratosphere/source/htc/server/rpc/htc_rpc_task_table.hpp
@@ -41,7 +41,7 @@ namespace ams::htc::server::rpc {
             #else
             static constexpr size_t MaxTaskSize = 0xE1D8;
             #endif
-            using TaskStorage = typename std::aligned_storage<MaxTaskSize, alignof(void *)>::type;
+            struct TaskStorage { alignas(alignof(void *)) std::byte _storage[MaxTaskSize]; };
         private:
             bool m_valid[MaxRpcCount]{};
             TaskStorage m_storages[MaxRpcCount]{};

--- a/libraries/libstratosphere/source/osdbg/impl/osdbg_types.hpp
+++ b/libraries/libstratosphere/source/osdbg/impl/osdbg_types.hpp
@@ -19,9 +19,13 @@
 namespace ams::osdbg::impl {
 
     template<size_t Size, int NumPointers, size_t Alignment>
-    using AlignedStorageIlp32 = typename std::aligned_storage<Size + NumPointers * sizeof(u32), Alignment>::type;
+    struct AlignedStorageIlp32 {
+        alignas(Alignment) std::byte _storage[Size + NumPointers * sizeof(u32)];
+    };
 
     template<size_t Size, int NumPointers, size_t Alignment>
-    using AlignedStorageLp64 = typename std::aligned_storage<Size + NumPointers * sizeof(u64), Alignment>::type;
+    struct AlignedStorageLp64 {
+        alignas(Alignment) std::byte _storage[Size + NumPointers * sizeof(u64)];
+    };
 
 }

--- a/libraries/libvapours/include/vapours/results/results_common.hpp
+++ b/libraries/libvapours/include/vapours/results/results_common.hpp
@@ -85,14 +85,13 @@ namespace ams {
         };
 
         /* Use CRTP for Results. */
-        template<typename Self>
         class ResultBase {
             public:
                 using BaseType = typename ResultTraits::BaseType;
                 static constexpr BaseType SuccessValue = ResultTraits::SuccessValue;
             public:
-                constexpr ALWAYS_INLINE BaseType GetModule() const { return ResultTraits::GetModuleFromValue(static_cast<const Self *>(this)->GetValue()); }
-                constexpr ALWAYS_INLINE BaseType GetDescription() const { return ResultTraits::GetDescriptionFromValue(static_cast<const Self *>(this)->GetValue()); }
+                constexpr ALWAYS_INLINE BaseType GetModule(this auto const &self) { return ResultTraits::GetModuleFromValue(self.GetValue()); }
+                constexpr ALWAYS_INLINE BaseType GetDescription(this auto const &self) { return ResultTraits::GetDescriptionFromValue(self.GetValue()); }
         };
 
         class ResultInternalAccessor;
@@ -101,10 +100,10 @@ namespace ams {
 
     class ResultSuccess;
 
-    class Result final : public result::impl::ResultBase<Result> {
+    class Result final : public result::impl::ResultBase {
         friend class result::impl::ResultInternalAccessor;
         public:
-            using Base = typename result::impl::ResultBase<Result>;
+            using Base = typename result::impl::ResultBase;
         private:
             typename Base::BaseType m_value;
         private:
@@ -157,9 +156,9 @@ namespace ams {
 
     }
 
-    class ResultSuccess final : public result::impl::ResultBase<ResultSuccess> {
+    class ResultSuccess final : public result::impl::ResultBase {
         public:
-            using Base = typename result::impl::ResultBase<ResultSuccess>;
+            using Base = typename result::impl::ResultBase;
         public:
             constexpr ALWAYS_INLINE operator Result() const { return result::impl::MakeResult(Base::SuccessValue); }
             static constexpr ALWAYS_INLINE bool CanAccept(Result result) { return result.IsSuccess(); }
@@ -189,9 +188,9 @@ namespace ams {
     namespace result::impl {
 
         template<ResultTraits::BaseType _Module, ResultTraits::BaseType _Description>
-        class ResultErrorBase : public ResultBase<ResultErrorBase<_Module, _Description>> {
+        class ResultErrorBase : public ResultBase {
             public:
-                using Base = typename result::impl::ResultBase<ResultErrorBase<_Module, _Description>>;
+                using Base = typename result::impl::ResultBase;
                 static constexpr typename Base::BaseType Module = _Module;
                 static constexpr typename Base::BaseType Description = _Description;
                 static constexpr typename Base::BaseType Value = ResultTraits::MakeStaticValue<Module, Description>::value;

--- a/libraries/libvapours/include/vapours/svc/codegen/impl/svc_codegen_impl_code_generator.hpp
+++ b/libraries/libvapours/include/vapours/svc/codegen/impl/svc_codegen_impl_code_generator.hpp
@@ -201,7 +201,7 @@ namespace ams::svc::codegen::impl {
                 } else if constexpr (Size == 8) {
                     __asm__ __volatile__("ldr     x%c[r], [sp, %c[offset]]" :: [r]"i"(Reg), [offset]"i"(Offset) : "memory");
                 } else {
-                    static_assert(Size != Size);
+                    static_assert(false, "Invalid Size");
                 }
             }
 
@@ -212,7 +212,7 @@ namespace ams::svc::codegen::impl {
                 } else if constexpr (Size == 8) {
                     __asm__ __volatile__("ldp     x%c[r0], x%c[r1], [sp, %c[offset]]" :: [r0]"i"(Reg0), [r1]"i"(Reg1), [offset]"i"(Offset) : "memory");
                 } else {
-                    static_assert(Size != Size);
+                    static_assert(false, "Invalid Size");
                 }
             }
 
@@ -223,7 +223,7 @@ namespace ams::svc::codegen::impl {
                 } else if constexpr (Size == 8) {
                     __asm__ __volatile__("str     x%c[r], [sp, %c[offset]]" :: [r]"i"(Reg), [offset]"i"(Offset) : "memory");
                 } else {
-                    static_assert(Size != Size);
+                    static_assert(false, "Invalid Size");
                 }
             }
 
@@ -234,7 +234,7 @@ namespace ams::svc::codegen::impl {
                 } else if constexpr (Size == 8) {
                     __asm__ __volatile__("stp     x%c[r0], x%c[r1], [sp, %c[offset]]" :: [r0]"i"(Reg0), [r1]"i"(Reg1), [offset]"i"(Offset) : "memory");
                 } else {
-                    static_assert(Size != Size);
+                    static_assert(false, "Invalid Size");
                 }
             }
 

--- a/libraries/libvapours/include/vapours/svc/codegen/impl/svc_codegen_impl_layout_conversion.hpp
+++ b/libraries/libvapours/include/vapours/svc/codegen/impl/svc_codegen_impl_layout_conversion.hpp
@@ -461,7 +461,7 @@ namespace ams::svc::codegen::impl {
                 if constexpr (CodeGenKind == CodeGenerationKind::SvcInvocationToKernelProcedure) {
                     return Operation::ImplType::template CanGenerateCodeForSvcInvocationToKernelProcedure<Operation>(allocator);
                 } else {
-                    static_assert(CodeGenKind != CodeGenKind, "Invalid CodeGenerationKind");
+                    static_assert(false, "Invalid CodeGenerationKind");
                 }
             }
 
@@ -474,7 +474,7 @@ namespace ams::svc::codegen::impl {
                 } else if constexpr (CodeGenKind == CodeGenerationKind::KernelProcedureToSvcInvocation) {
                     Operation::ImplType::template GenerateCodeForKernelProcedureToSvcInvocation<Operation>(mcg);
                 } else {
-                    static_assert(CodeGenKind != CodeGenKind, "Invalid CodeGenerationKind");
+                    static_assert(false, "Invalid CodeGenerationKind");
                 }
             }
     };

--- a/libraries/libvapours/include/vapours/svc/codegen/impl/svc_codegen_impl_meta_code.hpp
+++ b/libraries/libvapours/include/vapours/svc/codegen/impl/svc_codegen_impl_meta_code.hpp
@@ -127,7 +127,7 @@ namespace ams::svc::codegen::impl {
         META_CODE_OPERATION_KIND_GENERATE_CODE(Pack)
         META_CODE_OPERATION_KIND_GENERATE_CODE(Unpack)
         META_CODE_OPERATION_KIND_GENERATE_CODE(LoadStackAddress)
-        else { static_assert(Kind != Kind, "Unknown MetaOperationKind"); }
+        else { static_assert(false, "Unknown MetaOperationKind"); }
         #undef META_CODE_OPERATION_KIND_GENERATE_CODE
     }
 

--- a/libraries/libvapours/include/vapours/util/arch/arm64/util_atomic.hpp
+++ b/libraries/libvapours/include/vapours/util/arch/arm64/util_atomic.hpp
@@ -157,7 +157,7 @@ namespace ams::util {
             } else if constexpr (Order == std::memory_order_acq_rel || Order == std::memory_order_seq_cst) {
                 return ::ams::util::impl::LoadAcquireExclusiveForAtomic(p);
             } else {
-                static_assert(Order != Order, "Invalid memory order");
+                static_assert(false, "Invalid memory order");
             }
         }
 
@@ -172,7 +172,7 @@ namespace ams::util {
             } else if constexpr (Order == std::memory_order_acq_rel || Order == std::memory_order_seq_cst) {
                 return ::ams::util::impl::StoreReleaseExclusiveForAtomic(p, s);
             } else {
-                static_assert(Order != Order, "Invalid memory order");
+                static_assert(false, "Invalid memory order");
             }
         }
 

--- a/libraries/libvapours/include/vapours/util/util_typed_storage.hpp
+++ b/libraries/libvapours/include/vapours/util/util_typed_storage.hpp
@@ -22,7 +22,7 @@ namespace ams::util {
 
     template<typename T, size_t Size = sizeof(T), size_t Align = alignof(T)>
     struct TypedStorage {
-        typename std::aligned_storage<Size, Align>::type _storage;
+        alignas(Align) std::byte _storage[Size];
     };
 
     template<typename T>

--- a/troposphere/daybreak/Makefile
+++ b/troposphere/daybreak/Makefile
@@ -61,7 +61,7 @@ CFLAGS	:=	-g -Wall -O2 -ffunction-sections \
 
 CFLAGS	+=	$(INCLUDE) -D__SWITCH__
 
-CXXFLAGS	:= $(CFLAGS) -std=gnu++20 -fno-exceptions -fno-rtti
+CXXFLAGS	:= $(CFLAGS) -std=gnu++23 -fno-exceptions -fno-rtti
 
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=$(DEVKITPRO)/libnx/switch.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)

--- a/troposphere/haze/Makefile
+++ b/troposphere/haze/Makefile
@@ -61,7 +61,7 @@ CFLAGS	:=	-g -Wall -O2 -ffunction-sections \
 
 CFLAGS	+=	$(INCLUDE) -D__SWITCH__
 
-CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++20
+CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++23
 
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=$(DEVKITPRO)/libnx/switch.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)


### PR DESCRIPTION
This fixes compilation errors when upgrading to GCC 14. Unfortunately, one of the issues introduced has a natural fix (thanks to https://cplusplus.github.io/CWG/issues/2518.html) that breaks compilation with GCC 13. 

Thus, this shouldn't be merged until devkitA64 has a public release using GCC 14 available, so that we can just tell people to upgrade to latest.