### PR TITLE
dmnt_extension

### DIFF
--- a/docs/features/cheats.md
+++ b/docs/features/cheats.md
@@ -62,11 +62,13 @@ Code type 0x1 performs a comparison of the contents of memory to a static value.
 If the condition is not met, all instructions until the appropriate End or Else conditional block terminator are skipped.
 
 #### Encoding
-`1TMC00AA AAAAAAAA VVVVVVVV (VVVVVVVV)`
+`1TMCXrAA AAAAAAAA VVVVVVVV (VVVVVVVV)`
 
-+ T: Width of memory write (1, 2, 4, or 8 bytes).
-+ M: Memory region to write to (0 = Main NSO, 1 = Heap, 2 = Alias, 3 = Aslr).
++ T: Width of memory read (1, 2, 4, or 8 bytes).
++ M: Memory region to read from (0 = Main NSO, 1 = Heap, 2 = Alias, 3 = Aslr, 4 = none).
 + C: Condition to use, see below.
++ X: Operand Type, see below.
++ r: Offset Register (operand types 1).
 + A: Immediate offset to use from memory region base.
 + V: Value to compare to.
 
@@ -78,6 +80,9 @@ If the condition is not met, all instructions until the appropriate End or Else 
 + 5: ==
 + 6: !=
 
+#### Operand Type
++ 0: Memory Base + Relative Offset
++ 1: Memory Base + Offset Register + Relative Offset
 ---
 
 ### Code Type 0x2: End Conditional Block
@@ -126,7 +131,7 @@ Code type 0x5 allows loading a value from memory into a register, either using a
 `5TMR00AA AAAAAAAA`
 
 + T: Width of memory read (1, 2, 4, or 8 bytes).
-+ M: Memory region to write to (0 = Main NSO, 1 = Heap, 2 = Alias, 3 = Aslr).
++ M: Memory region to write to (0 = Main NSO, 1 = Heap, 2 = Alias, 3 = Aslr, 4 = none).
 + R: Register to load value into.
 + A: Immediate offset to use from memory region base.
 
@@ -149,7 +154,7 @@ Code type 0x5 allows loading a value from memory into a register, either using a
 `5TMR3SAA AAAAAAAA`
 
 + T: Width of memory read (1, 2, 4, or 8 bytes).
-+ M: Memory region to write to (0 = Main NSO, 1 = Heap, 2 = Alias, 3 = Aslr).
++ M: Memory region to write to (0 = Main NSO, 1 = Heap, 2 = Alias, 3 = Aslr, 4 = none).
 + R: Register to load value into.
 + S: Register to use as offset register.
 + A: Immediate offset to use from memory region base.

--- a/docs/features/cheats.md
+++ b/docs/features/cheats.md
@@ -200,7 +200,7 @@ Code type 0x8 enters or skips a conditional block based on whether a key combina
 
 + k: Keypad mask to check against, see below.
 
-Note that for multiple button combinations, the bitmasks should be OR'd together. Also, bit 27 does not correspond to a button and instead acts as a no auto-repeat flag.
+Note that for multiple button combinations, the bitmasks should be ORd together.
 
 #### Keypad Values
 Note: This is the direct output of `hidKeysDown()`.
@@ -231,7 +231,6 @@ Note: This is the direct output of `hidKeysDown()`.
 + 0800000: Right Stick Down
 + 1000000: SL
 + 2000000: SR
-+ 8000000: No auto-repeat. When this bit is set, the conditional block executes only once when the keypad mask matches. The mask must stop matching to reset for the next trigger.
 
 ---
 
@@ -402,6 +401,61 @@ Code type 0xC3 reads or writes a static register with a given register.
 + x: Register index.
 
 ---
+
+### Code Type 0xC4: Begin Extended Keypress Conditional Block
+Code type 0xC4 enters or skips a conditional block based on whether a key combination is pressed.
+
+#### Encoding
+`C4r000kk kkkkkkkk`
+
++ r: Auto-repeat, see below.
++ kkkkkkkkkk: Keypad mask to check against output of `hidKeysDown()`.
+
+Note that for multiple button combinations, the bitmasks should be OR'd together.
+
+#### Auto-repeat
+
++ 0: The conditional block executes only once when the keypad mask matches. The mask must stop matching to reset for the next trigger.
++ 1: The conditional block executes as long as the keypad mask matches.
+
+#### Keypad Values
+Note: This is the direct output of `hidKeysDown()`.
+
++ 000000001: A
++ 000000002: B
++ 000000004: X
++ 000000008: Y
++ 000000010: Left Stick Pressed
++ 000000020: Right Stick Pressed
++ 000000040: L
++ 000000080: R
++ 000000100: ZL
++ 000000200: ZR
++ 000000400: Plus
++ 000000800: Minus
++ 000001000: Left
++ 000002000: Up
++ 000004000: Right
++ 000008000: Down
++ 000010000: Left Stick Left
++ 000020000: Left Stick Up
++ 000040000: Left Stick Right
++ 000080000: Left Stick Down
++ 000100000: Right Stick Left
++ 000200000: Right Stick Up
++ 000400000: Right Stick Right
++ 000800000: Right Stick Down
++ 001000000: SL Left Joy-Con
++ 002000000: SR Left Joy-Con
++ 004000000: SL Right Joy-Con
++ 008000000: SR Right Joy-Con
++ 010000000: Top button on Poké Ball Plus (Palma) controller
++ 020000000: Verification
++ 040000000: B button on Left NES/HVC controller in Handheld mode
++ 080000000: Left C button in N64 controller
++ 100000000: Up C button in N64 controller
++ 200000000: Right C button in N64 controller
++ 400000000: Down C button in N64 controller
 
 ### Code Type 0xF0: Double Extended-Width Instruction
 Code Type 0xF0 signals to the VM to treat the upper three nybbles of the first dword as instruction type, instead of just the upper nybble.

--- a/docs/features/cheats.md
+++ b/docs/features/cheats.md
@@ -49,7 +49,7 @@ Code type 0x0 allows writing a static value to a memory address.
 `0TMR00AA AAAAAAAA VVVVVVVV (VVVVVVVV)`
 
 + T: Width of memory write (1, 2, 4, or 8 bytes).
-+ M: Memory region to write to (0 = Main NSO, 1 = Heap, 2 = Alias, 3 = Aslr).
++ M: Memory region to write to (0 = Main NSO, 1 = Heap, 2 = Alias, 3 = Aslr, 4 = none).
 + R: Register to use as an offset from memory region base.
 + A: Immediate offset to use from memory region base.
 + V: Value to write.
@@ -137,6 +137,22 @@ Code type 0x5 allows loading a value from memory into a register, either using a
 + R: Register to load value into. (This register is also used as the base memory address).
 + A: Immediate offset to use from register R.
 
+#### Load from Register Address Encoding
+`5T0R2SAA AAAAAAAA`
+
++ T: Width of memory read (1, 2, 4, or 8 bytes).
++ R: Register to load value into. 
++ S: Register to use as the base memory address.
++ A: Immediate offset to use from register R.
+
+#### Load From Fixed Address Encoding with offset register
+`5TMR3SAA AAAAAAAA`
+
++ T: Width of memory read (1, 2, 4, or 8 bytes).
++ M: Memory region to write to (0 = Main NSO, 1 = Heap, 2 = Alias, 3 = Aslr).
++ R: Register to load value into.
++ S: Register to use as offset register.
++ A: Immediate offset to use from memory region base.
 ---
 
 ### Code Type 0x6: Store Static Value to Register Memory Address
@@ -215,6 +231,7 @@ Note: This is the direct output of `hidKeysDown()`.
 + 0800000: Right Stick Down
 + 1000000: SL
 + 2000000: SR
++ 8000000: when this is set button only activate code once per keydown, need to be release before the code will run again
 
 ---
 
@@ -250,6 +267,10 @@ Code type 0x9 allows performing arithmetic on registers.
 + 7: Logical Not (discards right-hand operand)
 + 8: Logical Xor
 + 9: None/Move (discards right-hand operand)
++ 10: Float Addition, Width force to 4 bytes
++ 11: Float Multiplication, Width force to 4 bytes
++ 12: Double Addition, Width force to 8 bytes
++ 13: Double Multiplication, Width force to 8 bytes
 
 ---
 
@@ -303,6 +324,7 @@ C0TcS2Ra aaaaaaaa
 C0TcS3Rr
 C0TcS400 VVVVVVVV (VVVVVVVV)
 C0TcS5X0
+C0Tcr6Ma aaaaaaaa VVVVVVVV (VVVVVVVV)
 ```
 
 + T: Width of memory write (1, 2, 4, or 8 bytes).
@@ -323,6 +345,7 @@ C0TcS5X0
 + 3: Register + Offset Register
 + 4: Static Value
 + 5: Other Register
++ 6: Compare [Memory Base + Offset Register + Relative Offset] against Static Value
 
 #### Conditions
 + 1: >

--- a/docs/features/cheats.md
+++ b/docs/features/cheats.md
@@ -271,11 +271,10 @@ Code type 0x9 allows performing arithmetic on registers.
 + 7: Logical Not (discards right-hand operand)
 + 8: Logical Xor
 + 9: None/Move (discards right-hand operand)
-+ 10: Float Addition, Width force to 4 bytes
-+ 11: Float Multiplication, Width force to 4 bytes
-+ 12: Double Addition, Width force to 8 bytes
-+ 13: Double Multiplication, Width force to 8 bytes
-
++ 10: Float Addition, T==4 single T==8 double
++ 11: Float Subtraction, T==4 single T==8 double
++ 12: Float Multiplication, T==4 single T==8 double
++ 13: Float Division, T==4 single T==8 double
 ---
 
 ### Code Type 0xA: Store Register to Memory Address

--- a/docs/features/cheats.md
+++ b/docs/features/cheats.md
@@ -49,7 +49,7 @@ Code type 0x0 allows writing a static value to a memory address.
 `0TMR00AA AAAAAAAA VVVVVVVV (VVVVVVVV)`
 
 + T: Width of memory write (1, 2, 4, or 8 bytes).
-+ M: Memory region to write to (0 = Main NSO, 1 = Heap, 2 = Alias, 3 = Aslr, 4 = none).
++ M: Memory region to write to (0 = Main NSO, 1 = Heap, 2 = Alias, 3 = Aslr, 4 = non-relative).
 + R: Register to use as an offset from memory region base.
 + A: Immediate offset to use from memory region base.
 + V: Value to write.
@@ -65,7 +65,7 @@ If the condition is not met, all instructions until the appropriate End or Else 
 `1TMCXrAA AAAAAAAA VVVVVVVV (VVVVVVVV)`
 
 + T: Width of memory read (1, 2, 4, or 8 bytes).
-+ M: Memory region to read from (0 = Main NSO, 1 = Heap, 2 = Alias, 3 = Aslr, 4 = none).
++ M: Memory region to read from (0 = Main NSO, 1 = Heap, 2 = Alias, 3 = Aslr, 4 = non-relative).
 + C: Condition to use, see below.
 + X: Operand Type, see below.
 + r: Offset Register (operand types 1).
@@ -131,7 +131,7 @@ Code type 0x5 allows loading a value from memory into a register, either using a
 `5TMR00AA AAAAAAAA`
 
 + T: Width of memory read (1, 2, 4, or 8 bytes).
-+ M: Memory region to write to (0 = Main NSO, 1 = Heap, 2 = Alias, 3 = Aslr, 4 = none).
++ M: Memory region to write to (0 = Main NSO, 1 = Heap, 2 = Alias, 3 = Aslr, 4 = non-relative).
 + R: Register to load value into.
 + A: Immediate offset to use from memory region base.
 
@@ -154,7 +154,7 @@ Code type 0x5 allows loading a value from memory into a register, either using a
 `5TMR3SAA AAAAAAAA`
 
 + T: Width of memory read (1, 2, 4, or 8 bytes).
-+ M: Memory region to write to (0 = Main NSO, 1 = Heap, 2 = Alias, 3 = Aslr, 4 = none).
++ M: Memory region to write to (0 = Main NSO, 1 = Heap, 2 = Alias, 3 = Aslr, 4 = non-relative).
 + R: Register to load value into.
 + S: Register to use as offset register.
 + A: Immediate offset to use from memory region base.
@@ -408,7 +408,7 @@ Code type 0xC3 reads or writes a static register with a given register.
 Code type 0xC4 enters or skips a conditional block based on whether a key combination is pressed.
 
 #### Encoding
-`C4r000kk kkkkkkkk`
+`C4r00000 kkkkkkkk kkkkkkkk`
 
 + r: Auto-repeat, see below.
 + kkkkkkkkkk: Keypad mask to check against output of `hidKeysDown()`.

--- a/docs/features/cheats.md
+++ b/docs/features/cheats.md
@@ -328,7 +328,6 @@ C0TcS2Ra aaaaaaaa
 C0TcS3Rr
 C0TcS400 VVVVVVVV (VVVVVVVV)
 C0TcS5X0
-C0Tcr6Ma aaaaaaaa VVVVVVVV (VVVVVVVV)
 ```
 
 + T: Width of memory write (1, 2, 4, or 8 bytes).
@@ -349,7 +348,6 @@ C0Tcr6Ma aaaaaaaa VVVVVVVV (VVVVVVVV)
 + 3: Register + Offset Register
 + 4: Static Value
 + 5: Other Register
-+ 6: Compare [Memory Base + Offset Register + Relative Offset] against Static Value
 
 #### Conditions
 + 1: >

--- a/docs/features/cheats.md
+++ b/docs/features/cheats.md
@@ -200,7 +200,7 @@ Code type 0x8 enters or skips a conditional block based on whether a key combina
 
 + k: Keypad mask to check against, see below.
 
-Note that for multiple button combinations, the bitmasks should be ORd together.
+Note that for multiple button combinations, the bitmasks should be OR'd together. Also, bit 27 does not correspond to a button and instead acts as a no auto-repeat flag.
 
 #### Keypad Values
 Note: This is the direct output of `hidKeysDown()`.

--- a/docs/features/cheats.md
+++ b/docs/features/cheats.md
@@ -231,7 +231,7 @@ Note: This is the direct output of `hidKeysDown()`.
 + 0800000: Right Stick Down
 + 1000000: SL
 + 2000000: SR
-+ 8000000: when this is set button only activate code once per keydown, need to be release before the code will run again
++ 8000000: No auto-repeat. When this bit is set, the conditional block executes only once when the keypad mask matches. The mask must stop matching to reset for the next trigger.
 
 ---
 

--- a/stratosphere/dmnt/source/cheat/impl/dmnt_cheat_vm.cpp
+++ b/stratosphere/dmnt/source/cheat/impl/dmnt_cheat_vm.cpp
@@ -1000,9 +1000,7 @@ namespace ams::dmnt::cheat::impl {
                 case CheatVmOpcodeType_BeginKeypressConditionalBlock:
                     /* Check for keypress. */
                     if (cur_opcode.begin_keypress_cond.key_mask > 0x8000000) {
-                        const u64 kDown = ~keyold & kHeld;
-                        
-                        if ((cur_opcode.begin_keypress_cond.key_mask & 0x7FFFFFF & kDown) != (cur_opcode.begin_keypress_cond.key_mask & 0x7FFFFFF)) {
+                        if ((cur_opcode.begin_keypress_cond.key_mask & 0x7FFFFFF & kHeld) != (cur_opcode.begin_keypress_cond.key_mask & 0x7FFFFFF) || (cur_opcode.begin_keypress_cond.key_mask & 0x7FFFFFF & keyold) == (cur_opcode.begin_keypress_cond.key_mask & 0x7FFFFFF)) {
                             /* Keys not pressed. Skip conditional block. */
                             this->SkipConditionalBlock(true);
                         }

--- a/stratosphere/dmnt/source/cheat/impl/dmnt_cheat_vm.cpp
+++ b/stratosphere/dmnt/source/cheat/impl/dmnt_cheat_vm.cpp
@@ -235,13 +235,6 @@ namespace ams::dmnt::cheat::impl {
                         this->LogToDebugFile("A Reg Idx: %x\n", opcode->begin_reg_cond.addr_reg_index);
                         this->LogToDebugFile("O Reg Idx: %x\n", opcode->begin_reg_cond.ofs_reg_index);
                         break;
-                    case CompareRegisterValueType_OffsetValue:
-                        this->LogToDebugFile("Comp Type: Offset Value\n");
-                        this->LogToDebugFile("Mem Type:  %x\n", opcode->begin_reg_cond.mem_type);
-                        this->LogToDebugFile("O Reg Idx: %x\n", opcode->begin_reg_cond.ofs_reg_index);
-                        this->LogToDebugFile("Rel Addr:  %lx\n", opcode->begin_reg_cond.rel_address);
-                        this->LogToDebugFile("Value:     %lx\n", opcode->begin_reg_cond.value.bit64);
-                        break;
                 }
                 break;
             case CheatVmOpcodeType_SaveRestoreRegister:
@@ -551,7 +544,6 @@ namespace ams::dmnt::cheat::impl {
                     /* C0TcS3Rr */
                     /* C0TcS400 VVVVVVVV (VVVVVVVV) */
                     /* C0TcS5X0 */
-                    /* C0Tcr6Ma aaaaaaaa VVVVVVVV (VVVVVVVV) */
                     /* C0 = opcode 0xC0 */
                     /* T = bit width */
                     /* c = condition type. */
@@ -591,12 +583,6 @@ namespace ams::dmnt::cheat::impl {
                         case CompareRegisterValueType_RegisterOfsReg:
                             opcode.begin_reg_cond.addr_reg_index = ((first_dword >> 4) & 0xF);
                             opcode.begin_reg_cond.ofs_reg_index = (first_dword & 0xF);
-                            break;
-                        case CompareRegisterValueType_OffsetValue:
-                            opcode.begin_reg_cond.mem_type = (MemoryAccessType)((first_dword >> 4) & 0xF);
-                            opcode.begin_reg_cond.rel_address = (((u64)(first_dword & 0xF) << 32ul) | ((u64)GetNextDword()));
-                            opcode.begin_reg_cond.ofs_reg_index = ((first_dword >> 12) & 0xF);
-                            opcode.begin_reg_cond.value = GetNextVmInt(opcode.begin_reg_cond.bit_width);
                             break;
                     }
                 }
@@ -1207,10 +1193,6 @@ namespace ams::dmnt::cheat::impl {
                                     break;
                                 case CompareRegisterValueType_RegisterOfsReg:
                                     cond_address = m_registers[cur_opcode.begin_reg_cond.addr_reg_index] + m_registers[cur_opcode.begin_reg_cond.ofs_reg_index];
-                                    break;
-                                case CompareRegisterValueType_OffsetValue:
-                                    cond_address = GetCheatProcessAddress(metadata, cur_opcode.begin_reg_cond.mem_type, cur_opcode.begin_reg_cond.rel_address + m_registers[cur_opcode.begin_reg_cond.ofs_reg_index]);
-                                    src_value = GetVmInt(cur_opcode.begin_reg_cond.value, cur_opcode.begin_reg_cond.bit_width);
                                     break;
                                 default:
                                     break;

--- a/stratosphere/dmnt/source/cheat/impl/dmnt_cheat_vm.cpp
+++ b/stratosphere/dmnt/source/cheat/impl/dmnt_cheat_vm.cpp
@@ -108,6 +108,8 @@ namespace ams::dmnt::cheat::impl {
                 this->LogToDebugFile("Bit Width: %x\n", opcode->begin_cond.bit_width);
                 this->LogToDebugFile("Mem Type:  %x\n", opcode->begin_cond.mem_type);
                 this->LogToDebugFile("Cond Type: %x\n", opcode->begin_cond.cond_type);
+                this->LogToDebugFile("Inc Ofs reg:   %d\n", opcode->begin_cond.include_ofs_reg);
+                this->LogToDebugFile("Ofs Reg Idx: %x\n", opcode->begin_cond.ofs_reg_index);
                 this->LogToDebugFile("Rel Addr:  %lx\n", opcode->begin_cond.rel_address);
                 this->LogToDebugFile("Value:     %lx\n", opcode->begin_cond.value.bit64);
                 break;
@@ -400,6 +402,8 @@ namespace ams::dmnt::cheat::impl {
                     opcode.begin_cond.bit_width = (first_dword >> 24) & 0xF;
                     opcode.begin_cond.mem_type = (MemoryAccessType)((first_dword >> 20) & 0xF);
                     opcode.begin_cond.cond_type = (ConditionalComparisonType)((first_dword >> 16) & 0xF);
+                    opcode.begin_cond.include_ofs_reg = ((first_dword >> 12) & 0xF) != 0;
+                    opcode.begin_cond.ofs_reg_index = ((first_dword >> 8) & 0xF);
                     opcode.begin_cond.rel_address = ((u64)(first_dword & 0xFF) << 32ul) | ((u64)second_dword);
                     opcode.begin_cond.value = GetNextVmInt(opcode.begin_cond.bit_width);
                 }
@@ -856,7 +860,7 @@ namespace ams::dmnt::cheat::impl {
                 case CheatVmOpcodeType_BeginConditionalBlock:
                     {
                         /* Read value from memory. */
-                        u64 src_address = GetCheatProcessAddress(metadata, cur_opcode.begin_cond.mem_type, cur_opcode.begin_cond.rel_address);
+                        u64 src_address = GetCheatProcessAddress(metadata, cur_opcode.begin_cond.mem_type, (cur_opcode.begin_cond.include_ofs_reg) ? m_registers[cur_opcode.begin_cond.ofs_reg_index] + cur_opcode.begin_cond.rel_address : cur_opcode.begin_cond.rel_address);
                         u64 src_value = 0;
                         switch (cur_opcode.store_static.bit_width) {
                             case 1:

--- a/stratosphere/dmnt/source/cheat/impl/dmnt_cheat_vm.cpp
+++ b/stratosphere/dmnt/source/cheat/impl/dmnt_cheat_vm.cpp
@@ -1060,21 +1060,29 @@ namespace ams::dmnt::cheat::impl {
                             case RegisterArithmeticType_None:
                                 res_val = operand_1_value;
                                 break;
-                            case RegisterArithmeticType_FloatAddition: {
-                                cur_opcode.perform_math_reg.bit_width = 4;
-                                *(float *)&res_val = *(float *)&operand_1_value + *(float *)&operand_2_value;
+                            case RegisterArithmeticType_FloatAddition:
+                                if (cur_opcode.perform_math_reg.bit_width == 4)
+                                    *(float *)&res_val = *(float *)&operand_1_value + *(float *)&operand_2_value;
+                                if (cur_opcode.perform_math_reg.bit_width == 8)
+                                    *(double *)&res_val = *(double *)&operand_1_value + *(double *)&operand_2_value;
+                                break;
+                            case RegisterArithmeticType_FloatSubtraction: {
+                                if (cur_opcode.perform_math_reg.bit_width == 4)
+                                    *(float *)&res_val = *(float *)&operand_1_value - *(float *)&operand_2_value;
+                                if (cur_opcode.perform_math_reg.bit_width == 8)
+                                    *(double *)&res_val = *(double *)&operand_1_value - *(double *)&operand_2_value;
                             } break;
                             case RegisterArithmeticType_FloatMultiplication: {
-                                cur_opcode.perform_math_reg.bit_width = 4;
-                                *(float *)&res_val = *(float *)&operand_1_value * *(float *)&operand_2_value;
+                                if (cur_opcode.perform_math_reg.bit_width == 4)
+                                    *(float *)&res_val = *(float *)&operand_1_value * *(float *)&operand_2_value;
+                                if (cur_opcode.perform_math_reg.bit_width == 8)
+                                    *(double *)&res_val = *(double *)&operand_1_value * *(double *)&operand_2_value;
                             } break;
-                            case RegisterArithmeticType_DoubleAddition: {
-                                cur_opcode.perform_math_reg.bit_width = 8;
-                                *(double *)&res_val = *(double *)&operand_1_value + *(double *)&operand_2_value;
-                            } break;
-                            case RegisterArithmeticType_DoubleMultiplication: {
-                                cur_opcode.perform_math_reg.bit_width = 8;
-                                *(double *)&res_val = *(double *)&operand_1_value * *(double *)&operand_2_value;
+                            case RegisterArithmeticType_FloatDivision: {
+                                if (cur_opcode.perform_math_reg.bit_width == 4)
+                                    *(float *)&res_val = *(float *)&operand_1_value / *(float *)&operand_2_value;
+                                if (cur_opcode.perform_math_reg.bit_width == 8)
+                                    *(double *)&res_val = *(double *)&operand_1_value / *(double *)&operand_2_value;
                             } break;
                         }
 

--- a/stratosphere/dmnt/source/cheat/impl/dmnt_cheat_vm.hpp
+++ b/stratosphere/dmnt/source/cheat/impl/dmnt_cheat_vm.hpp
@@ -43,6 +43,7 @@ namespace ams::dmnt::cheat::impl {
         CheatVmOpcodeType_SaveRestoreRegister = 0xC1,
         CheatVmOpcodeType_SaveRestoreRegisterMask = 0xC2,
         CheatVmOpcodeType_ReadWriteStaticRegister = 0xC3,
+        CheatVmOpcodeType_BeginExtendedKeypressConditionalBlock = 0xC4,
 
         /* This is a meta entry, and not a real opcode. */
         /* This is to facilitate multi-nybble instruction decoding. */
@@ -192,6 +193,11 @@ namespace ams::dmnt::cheat::impl {
         u32 key_mask;
     };
 
+    struct BeginExtendedKeypressConditionalOpcode {
+        u64 key_mask;
+        bool auto_repeat;
+    };
+
     struct PerformArithmeticRegisterOpcode {
         u32 bit_width;
         RegisterArithmeticType math_type;
@@ -266,6 +272,7 @@ namespace ams::dmnt::cheat::impl {
             StoreStaticToAddressOpcode str_static;
             PerformArithmeticStaticOpcode perform_math_static;
             BeginKeypressConditionalOpcode begin_keypress_cond;
+            BeginExtendedKeypressConditionalOpcode begin_ext_keypress_cond;
             PerformArithmeticRegisterOpcode perform_math_reg;
             StoreRegisterToAddressOpcode str_register;
             BeginRegisterConditionalOpcode begin_reg_cond;

--- a/stratosphere/dmnt/source/cheat/impl/dmnt_cheat_vm.hpp
+++ b/stratosphere/dmnt/source/cheat/impl/dmnt_cheat_vm.hpp
@@ -59,6 +59,7 @@ namespace ams::dmnt::cheat::impl {
         MemoryAccessType_Heap    = 1,
         MemoryAccessType_Alias   = 2,
         MemoryAccessType_Aslr    = 3,
+        MemoryAccessType_Blank   = 4,
     };
 
     enum ConditionalComparisonType : u32 {
@@ -84,6 +85,10 @@ namespace ams::dmnt::cheat::impl {
         RegisterArithmeticType_LogicalXor = 8,
 
         RegisterArithmeticType_None = 9,
+        RegisterArithmeticType_FloatAddition = 10,
+        RegisterArithmeticType_FloatMultiplication = 11,
+        RegisterArithmeticType_DoubleAddition = 12,
+        RegisterArithmeticType_DoubleMultiplication = 13,
     };
 
     enum StoreRegisterOffsetType : u32 {
@@ -102,6 +107,7 @@ namespace ams::dmnt::cheat::impl {
         CompareRegisterValueType_RegisterOfsReg = 3,
         CompareRegisterValueType_StaticValue = 4,
         CompareRegisterValueType_OtherRegister = 5,
+        CompareRegisterValueType_OffsetValue = 6,
     };
 
     enum SaveRestoreRegisterOpType : u32 {
@@ -161,7 +167,8 @@ namespace ams::dmnt::cheat::impl {
         u32 bit_width;
         MemoryAccessType mem_type;
         u32 reg_index;
-        bool load_from_reg;
+        u8 load_from_reg;
+        u8 offset_register;
         u64 rel_address;
     };
 

--- a/stratosphere/dmnt/source/cheat/impl/dmnt_cheat_vm.hpp
+++ b/stratosphere/dmnt/source/cheat/impl/dmnt_cheat_vm.hpp
@@ -145,6 +145,8 @@ namespace ams::dmnt::cheat::impl {
         u32 bit_width;
         MemoryAccessType mem_type;
         ConditionalComparisonType cond_type;
+        bool include_ofs_reg;
+        u32 ofs_reg_index;
         u64 rel_address;
         VmInt value;
     };

--- a/stratosphere/dmnt/source/cheat/impl/dmnt_cheat_vm.hpp
+++ b/stratosphere/dmnt/source/cheat/impl/dmnt_cheat_vm.hpp
@@ -60,7 +60,7 @@ namespace ams::dmnt::cheat::impl {
         MemoryAccessType_Heap    = 1,
         MemoryAccessType_Alias   = 2,
         MemoryAccessType_Aslr    = 3,
-        MemoryAccessType_Blank   = 4,
+        MemoryAccessType_NonRelative   = 4,
     };
 
     enum ConditionalComparisonType : u32 {

--- a/stratosphere/dmnt/source/cheat/impl/dmnt_cheat_vm.hpp
+++ b/stratosphere/dmnt/source/cheat/impl/dmnt_cheat_vm.hpp
@@ -87,9 +87,9 @@ namespace ams::dmnt::cheat::impl {
 
         RegisterArithmeticType_None = 9,
         RegisterArithmeticType_FloatAddition = 10,
-        RegisterArithmeticType_FloatMultiplication = 11,
-        RegisterArithmeticType_DoubleAddition = 12,
-        RegisterArithmeticType_DoubleMultiplication = 13,
+        RegisterArithmeticType_FloatSubtraction = 11,
+        RegisterArithmeticType_FloatMultiplication = 12,
+        RegisterArithmeticType_FloatDivision = 13,
     };
 
     enum StoreRegisterOffsetType : u32 {

--- a/stratosphere/dmnt/source/cheat/impl/dmnt_cheat_vm.hpp
+++ b/stratosphere/dmnt/source/cheat/impl/dmnt_cheat_vm.hpp
@@ -108,7 +108,6 @@ namespace ams::dmnt::cheat::impl {
         CompareRegisterValueType_RegisterOfsReg = 3,
         CompareRegisterValueType_StaticValue = 4,
         CompareRegisterValueType_OtherRegister = 5,
-        CompareRegisterValueType_OffsetValue = 6,
     };
 
     enum SaveRestoreRegisterOpType : u32 {


### PR DESCRIPTION
1. Extension to Type 0
	Purpose: Adding the "none" option to improve flexibility, especially when game code resides in a module. This allows the setup of register R such that R corresponds to the module's main address.
		M: Memory region to write to (0 = Main NSO, 1 = Heap, 2 = Alias, 3 = Aslr, 4 = none).

2. Extension to type 5
	Purpose: Introducing two new extensions for enhanced pointer chain manipulation.
	Extension 2
	Allows separate source and target registers, removing the need to save the source register for use in other cheats that share the initial part of a pointer chain.
		#### Load from Register Address Encoding
		`5T0R2SAA AAAAAAAA`
		+ T: Width of memory read (1, 2, 4, or 8 bytes).
		+ R: Register to load value into. 
		+ S: Register to use as the base memory address.
		+ A: Immediate offset to use from register R.
	Extension 3
	Useful for cases where game code resides in a module. It allows the setup of register R such that main + R points to the module’s main address.
		#### Load From Fixed Address Encoding with offset register
		`5TMR3SAA AAAAAAAA`
		+ T: Width of memory read (1, 2, 4, or 8 bytes).
		+ M: Memory region to write to (0 = Main NSO, 1 = Heap, 2 = Alias, 3 = Aslr).
		+ R: Register to load value into.
		+ S: Register to use as offset register.
		+ A: Immediate offset to use from memory region base.

3. Extension to type 8
	Purpose: Enhancing keypad values to support cheats that execute only once per key press, making them ideal for actions like incrementing or decrementing specific values.
		8000000: when this is set button only activate code once per keydown, need to be release before the code will run again

4. Extension to type 9
	Purpose: Adding support for new arithmetic operations to handle floating-point and double-precision calculations.
		New Arithmetic Types:
		+ 10: Float Addition, Width force to 4 bytes
		+ 11: Float Multiplication, Width force to 4 bytes
		+ 12: Double Addition, Width force to 8 bytes
		+ 13: Double Multiplication, Width force to 8 bytes

5. Extension to type C0
	Purpose: Adding extension 6 to validate a hook before applying hacks. This is particularly useful for games with multiple loadable modules, where the build ID alone may not prevent hacking the wrong code.
		C0Tcr6Ma aaaaaaaa VVVVVVVV (VVVVVVVV)
		6: Compare [Memory Base + Offset Register + Relative Offset] against Static Value