### PR TITLE
creport: Add better 32-bit support

### DIFF
--- a/stratosphere/creport/source/creport_crash_report.cpp
+++ b/stratosphere/creport/source/creport_crash_report.cpp
@@ -105,7 +105,7 @@ namespace ams::creport {
         if (this->OpenProcess(process_id)) {
             /* Parse info from the crashed process. */
             this->ProcessExceptions();
-            m_module_list->FindModulesFromThreadInfo(m_debug_handle, m_crashed_thread, this->Is64Bit());
+            m_module_list->FindModulesFromThreadInfo(m_debug_handle, m_crashed_thread);
             m_thread_list->ReadFromProcess(m_debug_handle, m_thread_tls_map, this->Is64Bit());
 
             /* Associate module list to threads. */
@@ -120,7 +120,7 @@ namespace ams::creport {
             /* Nintendo's creport finds extra modules by looking at all threads if application, */
             /* but there's no reason for us not to always go looking. */
             for (size_t i = 0; i < m_thread_list->GetThreadCount(); i++) {
-                m_module_list->FindModulesFromThreadInfo(m_debug_handle, m_thread_list->GetThreadInfo(i), this->Is64Bit());
+                m_module_list->FindModulesFromThreadInfo(m_debug_handle, m_thread_list->GetThreadInfo(i));
             }
 
             /* Cache the module base address to send to fatal. */
@@ -188,6 +188,7 @@ namespace ams::creport {
 
     void CrashReport::HandleDebugEventInfoCreateProcess(const svc::DebugEventInfo &d) {
         m_process_info = d.info.create_process;
+        m_module_list->SetIs64Bit(Is64Bit());
 
         /* On 5.0.0+, we want to parse out a dying message from application crashes. */
         if (hos::GetVersion() < hos::Version_5_0_0 || !IsApplication()) {

--- a/stratosphere/creport/source/creport_modules.hpp
+++ b/stratosphere/creport/source/creport_modules.hpp
@@ -37,13 +37,14 @@ namespace ams::creport {
             };
         private:
             os::NativeHandle m_debug_handle;
+            bool m_is_64_bit;
             size_t m_num_modules;
             ModuleInfo m_modules[ModuleCountMax];
 
             /* For pretty-printing. */
             char m_address_str_buf[1_KB];
         public:
-            ModuleList() : m_debug_handle(os::InvalidNativeHandle), m_num_modules(0) {
+            ModuleList() : m_debug_handle(os::InvalidNativeHandle), m_is_64_bit(true), m_num_modules(0) {
                 std::memset(m_modules, 0, sizeof(m_modules));
             }
 
@@ -55,12 +56,16 @@ namespace ams::creport {
                 return m_modules[i].start_address;
             }
 
-            void FindModulesFromThreadInfo(os::NativeHandle debug_handle, const ThreadInfo &thread, bool is_64_bit);
+            void SetIs64Bit(bool is_64_bit) {
+                m_is_64_bit = is_64_bit;
+            }
+
+            void FindModulesFromThreadInfo(os::NativeHandle debug_handle, const ThreadInfo &thread);
             const char *GetFormattedAddressString(uintptr_t address);
             void SaveToFile(ScopedFile &file);
         private:
-            bool TryFindModule(uintptr_t *out_address, uintptr_t guess, bool is_64_bit);
-            void TryAddModule(uintptr_t guess, bool is_64_bit);
+            bool TryFindModule(uintptr_t *out_address, uintptr_t guess);
+            void TryAddModule(uintptr_t guess);
             void GetModuleName(char *out_name, uintptr_t text_start, uintptr_t ro_start);
             void GetModuleId(u8 *out, uintptr_t ro_start);
             void DetectModuleSymbolTable(ModuleInfo &module);


### PR DESCRIPTION
This adds support for both Elf32_Dyn/Elf32_Sym and the 64 variants instead of just 64, so you can see symbols in 32-bit crash reports. I moved is_64_bit to a member variable in ModuleList from all of the args passed to member functions because it was needed in GetFormattedAddressString and it would be tedious to pass Is64Bit() to every GetFormattedAddressString call.