### PR TITLE
build: portability fixes

### DIFF
--- a/atmosphere.mk
+++ b/atmosphere.mk
@@ -107,7 +107,7 @@ dist-no-debug: package3 $(CURRENT_DIRECTORY)/$(ATMOSPHERE_OUT_DIR)
 	cp stratosphere/dmnt.gen2/$(ATMOSPHERE_OUT_DIR)/dmnt.gen2.nsp $(DIST_DIR)/stratosphere_romfs/atmosphere/contents/010000000000d609/exefs.nsp
 	cp stratosphere/TioServer/$(ATMOSPHERE_OUT_DIR)/TioServer.nsp $(DIST_DIR)/stratosphere_romfs/atmosphere/contents/010000000000d623/exefs.nsp
 	cp stratosphere/memlet/$(ATMOSPHERE_OUT_DIR)/memlet.nsp $(DIST_DIR)/stratosphere_romfs/atmosphere/contents/0100000000000421/exefs.nsp
-	@build_romfs $(DIST_DIR)/stratosphere_romfs $(DIST_DIR)/atmosphere/stratosphere.romfs
+	@PATH="$(DEVKITPRO)/tools/bin:$$PATH" build_romfs $(DIST_DIR)/stratosphere_romfs $(DIST_DIR)/atmosphere/stratosphere.romfs
 	rm -r $(DIST_DIR)/stratosphere_romfs
 	cp troposphere/reboot_to_payload/reboot_to_payload.nro $(DIST_DIR)/switch/reboot_to_payload.nro
 	cp troposphere/daybreak/daybreak.nro $(DIST_DIR)/switch/daybreak.nro
@@ -117,7 +117,7 @@ dist-no-debug: package3 $(CURRENT_DIRECTORY)/$(ATMOSPHERE_OUT_DIR)
 	cp fusee/$(ATMOSPHERE_BOOT_OUT_DIR)/fusee.bin $(CURRENT_DIRECTORY)/$(ATMOSPHERE_OUT_DIR)/fusee.bin
 
 package3: emummc fusee stratosphere mesosphere exosphere troposphere
-	@python fusee/build_package3.py $(CURRENT_DIRECTORY) $(ATMOSPHERE_OUT_DIR) $(ATMOSPHERE_BOOT_OUT_DIR) $(ATMOSPHERE_GIT_HASH) $(ATMOSPHERE_MAJOR_VERSION) $(ATMOSPHERE_MINOR_VERSION) $(ATMOSPHERE_MICRO_VERSION) 0 $(ATMOSPHERE_SUPPORTED_HOS_MAJOR_VERSION) $(ATMOSPHERE_SUPPORTED_HOS_MINOR_VERSION) $(ATMOSPHERE_SUPPORTED_HOS_MICRO_VERSION) 0
+	$(SILENTCMD)$(PYTHON) fusee/build_package3.py $(CURRENT_DIRECTORY) $(ATMOSPHERE_OUT_DIR) $(ATMOSPHERE_BOOT_OUT_DIR) $(ATMOSPHERE_GIT_HASH) $(ATMOSPHERE_MAJOR_VERSION) $(ATMOSPHERE_MINOR_VERSION) $(ATMOSPHERE_MICRO_VERSION) 0 $(ATMOSPHERE_SUPPORTED_HOS_MAJOR_VERSION) $(ATMOSPHERE_SUPPORTED_HOS_MINOR_VERSION) $(ATMOSPHERE_SUPPORTED_HOS_MICRO_VERSION) 0
 	@echo "Built package3!"
 
 emummc:

--- a/exosphere/exosphere.mk
+++ b/exosphere/exosphere.mk
@@ -70,6 +70,6 @@ clean:
 	@$(MAKE) --no-print-directory -C $(ATMOSPHERE_LIBRARIES_DIR)/libexosphere -f $(ATMOSPHERE_LIBRARIES_DIR)/libexosphere/libexosphere.mk clean
 	@$(MAKE) --no-print-directory -C $(ATMOSPHERE_LIBRARIES_DIR)/libexosphere -f $(ATMOSPHERE_LIBRARIES_DIR)/libexosphere/libexosphere.mk clean ATMOSPHERE_CPU="$(strip $(ATMOSPHERE_BOOT_CPU))"
 	@rm -fr $(CURRENT_DIRECTORY)/$(ATMOSPHERE_OUT_DIR)
-	@for i in $(CURRENT_DIRECTORY)/$(ATMOSPHERE_OUT_DIR); do [ -d $$i ] && rmdir --ignore-fail-on-non-empty $$i || true; done
+	@for i in $(CURRENT_DIRECTORY)/$(ATMOSPHERE_OUT_DIR); do [ -d $$i ] && rmdir $$i 2>/dev/null || true; done
 
 .PHONY: all clean check_lib check_boot_lib check_loader_stub check_program check_mariko_fatal check_warmboot

--- a/exosphere/program/program.mk
+++ b/exosphere/program/program.mk
@@ -119,7 +119,7 @@ DEPENDS	:=	$(OFILES:.o=.d)
 #---------------------------------------------------------------------------------
 
 $(OUTPUT).lz4	:	$(OUTPUT).bin
-	@python $(CURRENT_DIRECTORY)/split_program.py $(OUTPUT).bin $(CURRENT_DIRECTORY)/$(ATMOSPHERE_OUT_DIR)
+	$(SILENTCMD)$(PYTHON) $(CURRENT_DIRECTORY)/split_program.py $(OUTPUT).bin $(CURRENT_DIRECTORY)/$(ATMOSPHERE_OUT_DIR)
 	@echo built ... $(notdir $@)
 
 $(OUTPUT).bin	:	$(OUTPUT).elf

--- a/fusee/fusee.mk
+++ b/fusee/fusee.mk
@@ -43,6 +43,6 @@ clean:
 	@$(MAKE) --no-print-directory -C $(CURRENT_DIRECTORY)/loader_stub -f $(CURRENT_DIRECTORY)/loader_stub/loader_stub.mk clean
 	@$(MAKE) --no-print-directory -C $(CURRENT_DIRECTORY)/program -f $(CURRENT_DIRECTORY)/program/program.mk clean
 	@rm -fr $(CURRENT_DIRECTORY)/$(ATMOSPHERE_OUT_DIR)
-	@for i in $(CURRENT_DIRECTORY)/$(ATMOSPHERE_OUT_DIR); do [ -d $$i ] && rmdir --ignore-fail-on-non-empty $$i || true; done
+	@for i in $(CURRENT_DIRECTORY)/$(ATMOSPHERE_OUT_DIR); do [ -d $$i ] && rmdir $$i 2>/dev/null || true; done
 
 .PHONY: all clean check_lib check_loader_stub check_program

--- a/fusee/program/program.mk
+++ b/fusee/program/program.mk
@@ -84,7 +84,7 @@ DEPENDS	:=	$(OFILES:.o=.d)
 #---------------------------------------------------------------------------------
 
 $(OUTPUT).lz4	:	$(OUTPUT).bin
-	@python $(CURRENT_DIRECTORY)/lz4_compress.py $(OUTPUT).bin $(OUTPUT).lz4
+	$(SILENTCMD)$(PYTHON) $(CURRENT_DIRECTORY)/lz4_compress.py $(OUTPUT).bin $(OUTPUT).lz4
 	@echo built ... $(notdir $@)
 
 $(OUTPUT).bin	:	$(OUTPUT).elf

--- a/libraries/config/common.mk
+++ b/libraries/config/common.mk
@@ -298,6 +298,23 @@ FIND_SOURCE_FILES=$(foreach dir,$1,$(filter-out $(notdir $(wildcard $(dir)/*.arc
 ATMOSPHERE_GCH_IDENTIFIER := $(ATMOSPHERE_FULL_NAME)
 
 #---------------------------------------------------------------------------------
+# Python.  The scripts should work with Python 2 or 3, but 2 is preferred.
+#---------------------------------------------------------------------------------
+PYTHON = $(shell command -v python >/dev/null && echo python || echo python3)
+
+#---------------------------------------------------------------------------------
+# Export MAKE:
+# GCC's LTO driver invokes Make internally.  This invocation respects both $(MAKE)
+# and $(MAKEFLAGS), but only if they're in the environment.  By default, MAKEFLAGS
+# is in the environment while MAKE isn't, so GCC will always use the default
+# `make` command, yet it inherits MAKEFLAGS from the copy of Make the user
+# invoked, which might have incompatible flags.  In practice this is an issue on
+# macOS when running e.g. `gmake -j32 -Otarget`.  This behavior is arguably a bug
+# in GCC and/or Make, but we can work around it by exporting MAKE.
+#---------------------------------------------------------------------------------
+export MAKE
+
+#---------------------------------------------------------------------------------
 # Rules for compiling pre-compiled headers
 #---------------------------------------------------------------------------------
 %.hpp.gch/$(ATMOSPHERE_GCH_IDENTIFIER): %.hpp %.hpp.gch

--- a/libraries/libexosphere/libexosphere.mk
+++ b/libraries/libexosphere/libexosphere.mk
@@ -104,7 +104,7 @@ clean:
 	@echo clean $(ATMOSPHERE_BUILD_NAME) ...
 	@rm -fr $(ATMOSPHERE_BUILD_DIR) $(ATMOSPHERE_OUT_DIR)
 	@rm -fr $(foreach hdr,$(GCH_DIRS),$(hdr)/$(ATMOSPHERE_GCH_IDENTIFIER))
-	@for i in $(GCH_DIRS); do [ -d $$i ] && rmdir --ignore-fail-on-non-empty $$i || true; done
+	@for i in $(GCH_DIRS); do [ -d $$i ] && rmdir $$i 2>/dev/null || true; done
 
 $(ATMOSPHERE_LIBRARY_DIR) $(ATMOSPHERE_BUILD_DIR) $(GCH_DIRS):
 	@[ -d $@ ] || mkdir -p $@

--- a/libraries/libmesosphere/libmesosphere.mk
+++ b/libraries/libmesosphere/libmesosphere.mk
@@ -86,7 +86,7 @@ clean:
 	@echo clean $(ATMOSPHERE_BUILD_NAME) ...
 	@rm -fr $(ATMOSPHERE_BUILD_DIR) $(ATMOSPHERE_OUT_DIR)
 	@rm -fr $(foreach hdr,$(GCH_DIRS),$(hdr)/$(ATMOSPHERE_GCH_IDENTIFIER))
-	@for i in $(GCH_DIRS); do [ -d $$i ] && rmdir --ignore-fail-on-non-empty $$i || true; done
+	@for i in $(GCH_DIRS); do [ -d $$i ] && rmdir $$i 2>/dev/null || true; done
 
 $(ATMOSPHERE_LIBRARY_DIR) $(ATMOSPHERE_BUILD_DIR) $(GCH_DIRS):
 	@[ -d $@ ] || mkdir -p $@

--- a/libraries/libstratosphere/libstratosphere.mk
+++ b/libraries/libstratosphere/libstratosphere.mk
@@ -118,7 +118,7 @@ clean:
 	@echo clean $(ATMOSPHERE_BUILD_NAME) ...
 	@rm -fr $(ATMOSPHERE_BUILD_DIR) $(ATMOSPHERE_OUT_DIR)
 	@rm -fr $(foreach hdr,$(GCH_DIRS),$(hdr)/$(ATMOSPHERE_GCH_IDENTIFIER))
-	@for i in $(GCH_DIRS); do [ -d $$i ] && rmdir --ignore-fail-on-non-empty $$i || true; done
+	@for i in $(GCH_DIRS); do [ -d $$i ] && rmdir $$i 2>/dev/null || true; done
 
 $(ATMOSPHERE_LIBRARY_DIR) $(ATMOSPHERE_BUILD_DIR) $(GCH_DIRS):
 	@[ -d $@ ] || mkdir -p $@

--- a/mesosphere/mesosphere.mk
+++ b/mesosphere/mesosphere.mk
@@ -8,7 +8,7 @@ include $(CURRENT_DIRECTORY)/../libraries/config/common.mk
 all: $(CURRENT_DIRECTORY)/$(ATMOSPHERE_OUT_DIR)/mesosphere.bin
 
 $(CURRENT_DIRECTORY)/$(ATMOSPHERE_OUT_DIR)/mesosphere.bin: $(CURRENT_DIRECTORY)/kernel/$(ATMOSPHERE_OUT_DIR)/kernel.bin $(CURRENT_DIRECTORY)/kernel_ldr/$(ATMOSPHERE_OUT_DIR)/kernel_ldr.bin $(CURRENT_DIRECTORY)/$(ATMOSPHERE_OUT_DIR)
-	@python build_mesosphere.py $(CURRENT_DIRECTORY)/kernel_ldr/$(ATMOSPHERE_OUT_DIR)/kernel_ldr.bin $(CURRENT_DIRECTORY)/kernel/$(ATMOSPHERE_OUT_DIR)/kernel.bin $(CURRENT_DIRECTORY)/$(ATMOSPHERE_OUT_DIR)/mesosphere.bin
+	$(SILENTCMD)$(PYTHON) build_mesosphere.py $(CURRENT_DIRECTORY)/kernel_ldr/$(ATMOSPHERE_OUT_DIR)/kernel_ldr.bin $(CURRENT_DIRECTORY)/kernel/$(ATMOSPHERE_OUT_DIR)/kernel.bin $(CURRENT_DIRECTORY)/$(ATMOSPHERE_OUT_DIR)/mesosphere.bin
 	@echo "Built mesosphere.bin..."
 
 $(CURRENT_DIRECTORY)/kernel/$(ATMOSPHERE_OUT_DIR)/kernel.bin: check_kernel
@@ -44,6 +44,6 @@ clean:
 	@$(MAKE) --no-print-directory -C $(CURRENT_DIRECTORY)/kernel -f $(CURRENT_DIRECTORY)/kernel/kernel.mk clean
 	@$(MAKE) --no-print-directory -C $(CURRENT_DIRECTORY)/kernel_ldr -f $(CURRENT_DIRECTORY)/kernel_ldr/kernel_ldr.mk clean
 	@rm -fr $(CURRENT_DIRECTORY)/$(ATMOSPHERE_OUT_DIR)/mesosphere.bin
-	@for i in $(CURRENT_DIRECTORY)/$(ATMOSPHERE_OUT_DIR); do [ -d $$i ] && rmdir --ignore-fail-on-non-empty $$i || true; done
+	@for i in $(CURRENT_DIRECTORY)/$(ATMOSPHERE_OUT_DIR); do [ -d $$i ] && rmdir $$i 2>/dev/null || true; done
 
 .PHONY: all clean check_lib check_kernel check_kernel_ldr

--- a/tests/TestFs/unit_test.mk
+++ b/tests/TestFs/unit_test.mk
@@ -95,7 +95,7 @@ $(ATMOSPHERE_OUT_DIR) $(ATMOSPHERE_BUILD_DIR):
 clean:
 	@echo clean ...
 	@rm -fr $(BUILD) $(BOARD_TARGET) $(TARGET).elf
-	@for i in $(ATMOSPHERE_OUT_DIR) $(ATMOSPHERE_BUILD_DIR); do [ -d $$i ] && rmdir --ignore-fail-on-non-empty $$i || true; done
+	@for i in $(ATMOSPHERE_OUT_DIR) $(ATMOSPHERE_BUILD_DIR); do [ -d $$i ] && rmdir $$i 2>/dev/null || true; done
 
 
 #---------------------------------------------------------------------------------

--- a/tests/TestOsEvents/unit_test.mk
+++ b/tests/TestOsEvents/unit_test.mk
@@ -95,7 +95,7 @@ $(ATMOSPHERE_OUT_DIR) $(ATMOSPHERE_BUILD_DIR):
 clean:
 	@echo clean ...
 	@rm -fr $(BUILD) $(BOARD_TARGET) $(TARGET).elf
-	@for i in $(ATMOSPHERE_OUT_DIR) $(ATMOSPHERE_BUILD_DIR); do [ -d $$i ] && rmdir --ignore-fail-on-non-empty $$i || true; done
+	@for i in $(ATMOSPHERE_OUT_DIR) $(ATMOSPHERE_BUILD_DIR); do [ -d $$i ] && rmdir $$i 2>/dev/null || true; done
 
 
 #---------------------------------------------------------------------------------

--- a/tests/TestSocket/unit_test.mk
+++ b/tests/TestSocket/unit_test.mk
@@ -95,7 +95,7 @@ $(ATMOSPHERE_OUT_DIR) $(ATMOSPHERE_BUILD_DIR):
 clean:
 	@echo clean ...
 	@rm -fr $(BUILD) $(BOARD_TARGET) $(TARGET).elf
-	@for i in $(ATMOSPHERE_OUT_DIR) $(ATMOSPHERE_BUILD_DIR); do [ -d $$i ] && rmdir --ignore-fail-on-non-empty $$i || true; done
+	@for i in $(ATMOSPHERE_OUT_DIR) $(ATMOSPHERE_BUILD_DIR); do [ -d $$i ] && rmdir $$i 2>/dev/null || true; done
 
 
 #---------------------------------------------------------------------------------

--- a/tests/TestStack/unit_test.mk
+++ b/tests/TestStack/unit_test.mk
@@ -95,7 +95,7 @@ $(ATMOSPHERE_OUT_DIR) $(ATMOSPHERE_BUILD_DIR):
 clean:
 	@echo clean ...
 	@rm -fr $(BUILD) $(BOARD_TARGET) $(TARGET).elf
-	@for i in $(ATMOSPHERE_OUT_DIR) $(ATMOSPHERE_BUILD_DIR); do [ -d $$i ] && rmdir --ignore-fail-on-non-empty $$i || true; done
+	@for i in $(ATMOSPHERE_OUT_DIR) $(ATMOSPHERE_BUILD_DIR); do [ -d $$i ] && rmdir $$i 2>/dev/null || true; done
 
 
 #---------------------------------------------------------------------------------


### PR DESCRIPTION
- Invoke Python scripts with `python3` if `python` is not available.

  Despite SciresM preferring Python 2, the scripts used in the build all
  worked in Python 3 already, so this is just a Makefile change.

- Export `MAKE` to work around a GNU bug.

  See the comment for details.

- `rmdir --ignore-fail-on-non-empty` -> `rmdir 2>/dev/null`

  macOS `rmdir` doesn't support `--ignore-fail-on-non-empty`.

  This is a slight downgrade in functionality, because now we ignore all
  errors from `rmdir` rather than just 'Directory not empty'.  I could
  have avoided this with a more complicated fix, but the benefit strikes
  me as not worth the complexity.  Let me know if you disagree.

- Append `$(DEVKITPRO)/tools/bin/` to `$PATH` when invoking
  `build_romfs`.

  This avoids the need to add devkitPro directories to `$PATH` when
  building Atmosphere.

  If you already have `build_romfs` in your PATH, then that will still
  take precedence.  (This seemed like the nicer option, though I don't
  have strong opinions.)