### PR TITLE
build: enable parallel builds with automatic single-thread fallback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,18 +4,19 @@ clean: clean-nx_release
 
 THIS_MAKEFILE     := $(abspath $(lastword $(MAKEFILE_LIST)))
 CURRENT_DIRECTORY := $(abspath $(dir $(THIS_MAKEFILE)))
+JOBS ?= $(shell nproc)
 
 define ATMOSPHERE_ADD_TARGET
 
 ATMOSPHERE_BUILD_CONFIGS += $(strip $1)
 
 $(strip $1):
-	@echo "Building $(strip $1)"
-	@$$(MAKE) -f $(CURRENT_DIRECTORY)/atmosphere.mk ATMOSPHERE_MAKEFILE_TARGET="$(strip $1)" ATMOSPHERE_BUILD_NAME="$(strip $2)" ATMOSPHERE_BOARD="$(strip $3)" ATMOSPHERE_CPU="$(strip $4)" $(strip $5)
+	@echo "Building $(strip $1) with $(JOBS) job(s)"
+	@$$(MAKE) -j$(JOBS) -f $(CURRENT_DIRECTORY)/atmosphere.mk ATMOSPHERE_MAKEFILE_TARGET="$(strip $1)" ATMOSPHERE_BUILD_NAME="$(strip $2)" ATMOSPHERE_BOARD="$(strip $3)" ATMOSPHERE_CPU="$(strip $4)" $(strip $5) || (echo "Parallel build failed, retrying with 1 job..." && $(MAKE) -j1 -f $(CURRENT_DIRECTORY)/atmosphere.mk ATMOSPHERE_MAKEFILE_TARGET="$(strip $1)" ATMOSPHERE_BUILD_NAME="$(strip $2)" ATMOSPHERE_BOARD="$(strip $3)" ATMOSPHERE_CPU="$(strip $4)" $(strip $5))
 
 clean-$(strip $1):
-	@echo "Cleaning $(strip $1)"
-	@$$(MAKE) -f $(CURRENT_DIRECTORY)/atmosphere.mk clean ATMOSPHERE_MAKEFILE_TARGET="$(strip $1)" ATMOSPHERE_BUILD_NAME="$(strip $2)" ATMOSPHERE_BOARD="$(strip $3)" ATMOSPHERE_CPU="$(strip $4)" $(strip $5)
+	@echo "Cleaning $(strip $1) with $(JOBS) job(s)"
+	@$$(MAKE) -j$(JOBS) -f $(CURRENT_DIRECTORY)/atmosphere.mk clean ATMOSPHERE_MAKEFILE_TARGET="$(strip $1)" ATMOSPHERE_BUILD_NAME="$(strip $2)" ATMOSPHERE_BOARD="$(strip $3)" ATMOSPHERE_CPU="$(strip $4)" $(strip $5) || (echo "Parallel clean failed, retrying with 1 job..." && $(MAKE) -j1 -f $(CURRENT_DIRECTORY)/atmosphere.mk clean ATMOSPHERE_MAKEFILE_TARGET="$(strip $1)" ATMOSPHERE_BUILD_NAME="$(strip $2)" ATMOSPHERE_BOARD="$(strip $3)" ATMOSPHERE_CPU="$(strip $4)" $(strip $5))
 
 endef
 


### PR DESCRIPTION
### Summary
This change updates the top-level Makefile to:
- Detect available CPU cores with `nproc` and use them for parallel builds by default.
- Automatically retry a target with `-j1` if the parallel build fails (e.g. due to race conditions in certain modules).
- Apply the same logic to `clean` targets.

### Rationale
Most contributors benefit from faster builds when using all CPU cores.  
However, some targets (such as `haze`) can occasionally fail in parallel mode.  
This change improves build speed for the majority of cases while preserving reliability by falling back to single-thread mode automatically.

### Testing
Tested on Linux (WSL2) with devkitPro toolchain:
- `make` → builds in parallel successfully.
- Simulated parallel failure → retried automatically with `-j1` and completed.
- `make -j1` → still works as expected.
- `make clean` → cleans in parallel, falls back to `-j1` if needed.

No changes to target names, variables, or build outputs.  
Existing workflows remain fully compatible.
