### PR TITLE
Decrease ExtraSystemMemorySizeAtmosphere to 24_MB

### DIFF
--- a/stratosphere/pm/source/impl/pm_spec.cpp
+++ b/stratosphere/pm/source/impl/pm_spec.cpp
@@ -33,7 +33,7 @@ namespace ams::pm::impl {
         constexpr size_t ReservedMemorySize600       = 5_MB;
 
         /* Atmosphere always allocates extra memory for system usage. */
-        constexpr size_t ExtraSystemMemorySizeAtmosphere    = 32_MB;
+        constexpr size_t ExtraSystemMemorySizeAtmosphere    = 24_MB;
 
         /* Desired extra threads. */
         constexpr u64 BaseApplicationThreads  = 96;


### PR DESCRIPTION
Web Applet (LibAppletWe) is crashing with a memory error (0x800D2) in games like Scarlet/Violet.  Fixed similarly in commit 7a69f2f06 in 2023.