### PR TITLE
Add a cache redirection option to fs-mitm

### DIFF
--- a/config_templates/system_settings.ini
+++ b/config_templates/system_settings.ini
@@ -46,6 +46,12 @@
 ; NOTE: EXPERIMENTAL
 ; If you do not know what you are doing, do not touch this yet.
 ; fsmitm_redirect_saves_to_sd = u8!0x0
+; Controls whether fs.mitm should redirect cache save files
+; to directories on the sd card.
+; 0 = Do not redirect, 1 = Redirect.
+; NOTE: EXPERIMENTAL
+; If you do not know what you are doing, do not touch this yet.
+; fsmitm_redirect_cache_to_sd = u8!0x0
 ; Controls whether am sees system settings "DebugModeFlag" as
 ; enabled or disabled.
 ; 0 = Disabled (not debug mode), 1 = Enabled (debug mode)

--- a/docs/features/configurations.md
+++ b/docs/features/configurations.md
@@ -123,3 +123,4 @@ Atmosphère supports customizing CFW behavior based on the presence of `flags` o
 The following flags are supported on a per-program basis, by placing `<flag_name>.flag` inside `/atmosphere/contents/<program_id>/flags/`:
 + `boot2`, which indicates that the program should be launched during the `boot2` process.
 + `redirect_save`, which indicates that the program wants its savedata to be redirected to the SD card.
++ `redirect_cache`, which indicates that the program wants its cache storage to be redirected to the SD card.

--- a/stratosphere/ams_mitm/source/fs_mitm/fs_mitm_service.cpp
+++ b/stratosphere/ams_mitm/source/fs_mitm/fs_mitm_service.cpp
@@ -200,14 +200,16 @@ namespace ams::mitm::fs {
         const bool is_game_or_hbl = m_client_info.override_status.IsHbl() || ncm::IsApplicationId(m_client_info.program_id);
         R_UNLESS(is_game_or_hbl, sm::mitm::ResultShouldForwardToSession());
 
-        /* Only redirect if the appropriate system setting is set. */
-        R_UNLESS(GetSettingsItemBooleanValue("atmosphere", "fsmitm_redirect_saves_to_sd"), sm::mitm::ResultShouldForwardToSession());
-
-        /* Only redirect if the specific title being accessed has a redirect save flag. */
-        R_UNLESS(cfg::HasContentSpecificFlag(m_client_info.program_id, "redirect_save"), sm::mitm::ResultShouldForwardToSession());
-
-        /* Only redirect account savedata. */
-        R_UNLESS(attribute.type == fs::SaveDataType::Account, sm::mitm::ResultShouldForwardToSession());
+        /* Determine whether we should redirect based on save type. */
+        bool should_redirect = false;
+        if (attribute.type == fs::SaveDataType::Account) {
+            should_redirect = GetSettingsItemBooleanValue("atmosphere", "fsmitm_redirect_saves_to_sd")
+                           && cfg::HasContentSpecificFlag(m_client_info.program_id, "redirect_save");
+        } else if (attribute.type == fs::SaveDataType::Cache) {
+            should_redirect = GetSettingsItemBooleanValue("atmosphere", "fsmitm_redirect_cache_to_sd")
+                           && cfg::HasContentSpecificFlag(m_client_info.program_id, "redirect_cache");
+        }
+        R_UNLESS(should_redirect, sm::mitm::ResultShouldForwardToSession());
 
         /* Get enum type for space id. */
         auto space_id = static_cast<FsSaveDataSpaceId>(_space_id);

--- a/stratosphere/ams_mitm/source/set_mitm/settings_sd_kvs.cpp
+++ b/stratosphere/ams_mitm/source/set_mitm/settings_sd_kvs.cpp
@@ -359,6 +359,13 @@ namespace ams::settings::fwdbg {
             /* If you do not know what you are doing, do not touch this yet. */
             R_ABORT_UNLESS(ParseSettingsItemValue("atmosphere", "fsmitm_redirect_saves_to_sd", "u8!0x0"));
 
+            /* Controls whether fs.mitm should redirect cache save files */
+            /* to directories on the sd card. */
+            /* 0 = Do not redirect, 1 = Redirect. */
+            /* NOTE: EXPERIMENTAL */
+            /* If you do not know what you are doing, do not touch this yet. */
+            R_ABORT_UNLESS(ParseSettingsItemValue("atmosphere", "fsmitm_redirect_cache_to_sd", "u8!0x0"));
+
             /* Controls whether am sees system settings "DebugModeFlag" as */
             /* enabled or disabled. */
             /* 0 = Disabled (not debug mode), 1 = Enabled (debug mode) */


### PR DESCRIPTION
Following the same pattern as save redirection to SD, allow the user to enable cache redirection to SD.
* Adds an option to  enable cache redir in system_settings.ini
    (`atmosphere!fsmitm_redirect_cache_to_sd = u8!0x1`)

* Adds cache redir flag for apps
    (`/atmosphere/contents/<PROGRAM_ID>/flags/redirect_cache.flag`)