### PR TITLE
[Feature] Auto dram cfg & Auto memory mode

### DIFF
--- a/config_templates/exosphere.ini
+++ b/config_templates/exosphere.ini
@@ -15,6 +15,13 @@
 #  Desc: Controls whether userland has access to the PMU registers.
 #  NOTE: It is unknown what effects this has on official code.
 
+# Key: enable_mem_mode, default: 0.
+#  Desc: Controls whether boot config memory mode is taken into account
+#   for retail units. This does not affect development units.
+#  NOTE: On retail units max ram size is capped to 4GB.
+#   Enabling this will use the boot config memory mode parameter,
+#   which by default is auto and size gets set based on physical size.
+
 # Key: blank_prodinfo_sysmmc, default: 0.
 #  Desc: Controls whether PRODINFO should be blanked in sysmmc.
 #   This will cause the system to see dummied out keys and
@@ -51,6 +58,7 @@ debugmode=1
 debugmode_user=0
 disable_user_exception_handlers=0
 enable_user_pmu_access=0
+enable_mem_mode=0
 blank_prodinfo_sysmmc=0
 blank_prodinfo_emummc=0
 allow_writing_to_cal_sysmmc=0

--- a/exosphere/program/source/smc/secmon_smc_info.cpp
+++ b/exosphere/program/source/smc/secmon_smc_info.cpp
@@ -132,10 +132,13 @@ namespace ams::secmon::smc {
         }
 
         u32 GetMemoryMode() {
-            /* Unless development function is enabled, we're 4 GB. */
+            /* Unless development function or forced boot config memory size is enabled, we're 4 GB. */
             u32 memory_mode = pkg1::MemoryMode_4GB;
 
-            if (const auto &bcd = GetBootConfig().data; bcd.IsDevelopmentFunctionEnabled()) {
+            const auto &bcd = GetBootConfig().data;
+            const auto &sc  = GetSecmonConfiguration(); /* Exosphere extensions */
+
+            if (bcd.IsDevelopmentFunctionEnabled() || sc.IsBootConfigMemoryModeEnabled()) {
                 memory_mode = GetMemoryMode(bcd.GetMemoryMode());
             }
 
@@ -146,17 +149,19 @@ namespace ams::secmon::smc {
             pkg1::MemorySize memory_size = pkg1::MemorySize_4GB;
             util::BitPack32 value = {};
 
-            if (const auto &bcd = GetBootConfig().data; bcd.IsDevelopmentFunctionEnabled()) {
-                memory_size = GetMemorySize(GetMemoryMode(bcd.GetMemoryMode()));
+            const auto &bcd = GetBootConfig().data;
+            const auto &sc  = GetSecmonConfiguration(); /* Exosphere extensions */
 
+            if (bcd.IsDevelopmentFunctionEnabled()) {
                 value.Set<KernelConfiguration::Flags1>(bcd.GetKernelFlags1());
                 value.Set<KernelConfiguration::Flags0>(bcd.GetKernelFlags0());
             }
 
-            value.Set<KernelConfiguration::PhysicalMemorySize>(memory_size);
+            if (bcd.IsDevelopmentFunctionEnabled() || sc.IsBootConfigMemoryModeEnabled()) {
+                memory_size = GetMemorySize(GetMemoryMode(bcd.GetMemoryMode()));
+            }
 
-            /* Exosphere extensions. */
-            const auto &sc = GetSecmonConfiguration();
+            value.Set<KernelConfiguration::PhysicalMemorySize>(memory_size);
 
             if (!sc.DisableUserModeExceptionHandlers()) {
                 value.Set<KernelConfiguration::EnableUserExceptionHandlers>(true);

--- a/fusee/program/source/fusee_setup_horizon.cpp
+++ b/fusee/program/source/fusee_setup_horizon.cpp
@@ -543,6 +543,12 @@ namespace ams::nxboot {
                                 } else {
                                     storage_ctx.flags[0] &= ~secmon::SecureMonitorConfigurationFlag_EnableUserModePerformanceCounterAccess;
                                 }
+                            } else if (std::strcmp(entry.key, "enable_mem_mode") == 0) {
+                                if (entry.value[0] == '1') {
+                                    storage_ctx.flags[0] |= secmon::SecureMonitorConfigurationFlag_BootConfigMemoryModeEnabled;
+                                } else {
+                                    storage_ctx.flags[0] &= ~secmon::SecureMonitorConfigurationFlag_BootConfigMemoryModeEnabled;
+                                }
                             } else if (std::strcmp(entry.key, "blank_prodinfo_sysmmc") == 0) {
                                 if (!emummc_enabled) {
                                     if (entry.value[0] == '1') {

--- a/libraries/libexosphere/include/exosphere/secmon/secmon_monitor_context.hpp
+++ b/libraries/libexosphere/include/exosphere/secmon/secmon_monitor_context.hpp
@@ -30,6 +30,7 @@ namespace ams::secmon {
         SecureMonitorConfigurationFlag_ShouldUseBlankCalibrationBinary        = (1u << 5),
         SecureMonitorConfigurationFlag_AllowWritingToCalibrationBinarySysmmc  = (1u << 6),
         SecureMonitorConfigurationFlag_ForceEnableUsb30                       = (1u << 7),
+        SecureMonitorConfigurationFlag_BootConfigMemoryModeEnabled            = (1u << 8),
 
         SecureMonitorConfigurationFlag_Default = SecureMonitorConfigurationFlag_IsDevelopmentFunctionEnabledForKernel,
     };
@@ -103,6 +104,7 @@ namespace ams::secmon {
         constexpr bool ShouldUseBlankCalibrationBinary()        const { return (this->flags[0] & SecureMonitorConfigurationFlag_ShouldUseBlankCalibrationBinary)        != 0; }
         constexpr bool AllowWritingToCalibrationBinarySysmmc()  const { return (this->flags[0] & SecureMonitorConfigurationFlag_AllowWritingToCalibrationBinarySysmmc)  != 0; }
         constexpr bool IsUsb30ForceEnabled()                    const { return (this->flags[0] & SecureMonitorConfigurationFlag_ForceEnableUsb30)                       != 0; }
+        constexpr bool IsBootConfigMemoryModeEnabled()          const { return (this->flags[0] & SecureMonitorConfigurationFlag_BootConfigMemoryModeEnabled)            != 0; }
 
         constexpr bool IsDevelopmentFunctionEnabled(bool for_kern) const { return for_kern ? this->IsDevelopmentFunctionEnabledForKernel() : this->IsDevelopmentFunctionEnabledForUser(); }
     };


### PR DESCRIPTION
This PR adds the following:

`exosphere: automatically adjust dram id if needed`:
Support for automatic detection and adjusting of DRAM ID reporting when unit has an 8GB RAM mod and fuses couldn't be burnt.

By comparing the actual physical size from the locked MC registers and DRAM ID supposed size, the id gets adjusted when it doesn't match.
This allows PCV to correctly train the ram frequencies needed for avoiding crashes or degraded performance.

`exosphere: allow memory mode to be used on retail`
A simple flag configured at bootloader time allows user to bypass the 4GB max ram allocation limit on retail units by enabling auto memory mode.
Enabling this with 8GB ram, sets max to 8GB, otherwise it gets limited to stock max 4GB.
On development units or devices with 4GB, it does nothing since ram config matches max size limit anyway.

By previous communication with @lulle2007200, the second part of this PR replaces https://github.com/Atmosphere-NX/Atmosphere/pull/2711
The new implementation is compacted to actually enable NX boot config for retail units.
The default at this time is auto memory mode which should cover 100% of actual real use cases, but still allows additions in the future.

To sum up:
1st part is for allowing automatic dram config detection with 8GB ram mods.
2nd part is for allowing user to choose between 4GB or 8GB max ram limit in such cases.

EDIT:
The automatic detection also allows T210 units with 8GB ram mods and burnt fuse dram id to 7, to boot too.