### PR TITLE
fs.mitm: Add "Until Then" as another game which needs stolen heap for layeredfs

### DIFF
--- a/stratosphere/ams_mitm/source/fs_mitm/fsmitm_romfs.cpp
+++ b/stratosphere/ams_mitm/source/fs_mitm/fsmitm_romfs.cpp
@@ -36,6 +36,11 @@ namespace ams::mitm::fs {
             };
 
             constexpr const ApplicationWithDynamicHeapInfo ApplicationsWithDynamicHeap[] = {
+                /* Until Then. */
+                /* Requirement ~34 MB. */
+                /* No particular heap sensitivity. */
+                { 0x010019C023004000,  16_MB, 0_MB },
+
                 /* Trails in the Sky 1st Chapter. */
                 /* Requirement ? MB. 16 MB stolen heap fixes a crash, though. */
                 /* Unknown heap sensitivity. */


### PR DESCRIPTION
Atmosphere fatals when trying to load any romfs mod.

per romfs_diag output:

1.0.0 version:
```
=== Count by Type ===
AllocationType_FileName:             0
AllocationType_DirName:              0
AllocationType_FullPath:             225107
AllocationType_SourceInfo:           1
AllocationType_BuildFileContext:     0
AllocationType_BuildDirContext:      0
AllocationType_TableCache:           0
AllocationType_DirPointerArray:      0
AllocationType_DirContextSet:        0
AllocationType_FileContextSet:       0
AllocationType_Header:               0
===

=== Peak Count by Type ===
AllocationType_FileName:             225107
AllocationType_DirName:              17263
AllocationType_FullPath:             225107
AllocationType_SourceInfo:           2
AllocationType_BuildFileContext:     225107
AllocationType_BuildDirContext:      17263
AllocationType_TableCache:           1
AllocationType_DirPointerArray:      10
AllocationType_DirContextSet:        17263
AllocationType_FileContextSet:       225107
AllocationType_Header:               0
===

=== Allocation by Type ===
AllocationType_FileName:             0 (0 KiB)
AllocationType_DirName:              0 (0 KiB)
AllocationType_FullPath:             17541854 (17130 KiB)
AllocationType_SourceInfo:           8388608 (8192 KiB)
AllocationType_BuildFileContext:     0 (0 KiB)
AllocationType_BuildDirContext:      0 (0 KiB)
AllocationType_TableCache:           0 (0 KiB)
AllocationType_DirPointerArray:      0 (0 KiB)
AllocationType_DirContextSet:        0 (0 KiB)
AllocationType_FileContextSet:       0 (0 KiB)
AllocationType_Header:               0 (0 KiB)
===

=== Peak by Type ===
AllocationType_FileName:             6958354 (6795 KiB)
AllocationType_DirName:              404426 (394 KiB)
AllocationType_FullPath:             17541854 (17130 KiB)
AllocationType_SourceInfo:           12582912 (12288 KiB)
AllocationType_BuildFileContext:     14406848 (14069 KiB)
AllocationType_BuildDirContext:      966728 (944 KiB)
AllocationType_TableCache:           16384 (16 KiB)
AllocationType_DirPointerArray:      2792 (2 KiB)
AllocationType_DirContextSet:        690520 (674 KiB)
AllocationType_FileContextSet:       9004280 (8793 KiB)
AllocationType_Header:               0 (0 KiB)
===

=== Stats ===
Total Allocated: 25930462 (25322 KiB)
Peak Allocated:  35029273 (34208 KiB)
Total Count: 225108
Peak Count:  727113
===

```

1.0.5 version:
```
=== Count by Type ===
AllocationType_FileName:             0
AllocationType_DirName:              0
AllocationType_FullPath:             229936
AllocationType_SourceInfo:           1
AllocationType_BuildFileContext:     0
AllocationType_BuildDirContext:      0
AllocationType_TableCache:           0
AllocationType_DirPointerArray:      0
AllocationType_DirContextSet:        0
AllocationType_FileContextSet:       0
AllocationType_Header:               0
===

=== Peak Count by Type ===
AllocationType_FileName:             229936
AllocationType_DirName:              17382
AllocationType_FullPath:             229936
AllocationType_SourceInfo:           2
AllocationType_BuildFileContext:     229936
AllocationType_BuildDirContext:      17382
AllocationType_TableCache:           1
AllocationType_DirPointerArray:      10
AllocationType_DirContextSet:        17382
AllocationType_FileContextSet:       229936
AllocationType_Header:               0
===

=== Allocation by Type ===
AllocationType_FileName:             0 (0 KiB)
AllocationType_DirName:              0 (0 KiB)
AllocationType_FullPath:             17884819 (17465 KiB)
AllocationType_SourceInfo:           8388608 (8192 KiB)
AllocationType_BuildFileContext:     0 (0 KiB)
AllocationType_BuildDirContext:      0 (0 KiB)
AllocationType_TableCache:           0 (0 KiB)
AllocationType_DirPointerArray:      0 (0 KiB)
AllocationType_DirContextSet:        0 (0 KiB)
AllocationType_FileContextSet:       0 (0 KiB)
AllocationType_Header:               0 (0 KiB)
===

=== Peak by Type ===
AllocationType_FileName:             7171519 (7003 KiB)
AllocationType_DirName:              405721 (396 KiB)
AllocationType_FullPath:             17884819 (17465 KiB)
AllocationType_SourceInfo:           12582912 (12288 KiB)
AllocationType_BuildFileContext:     14715904 (14371 KiB)
AllocationType_BuildDirContext:      973392 (950 KiB)
AllocationType_TableCache:           16384 (16 KiB)
AllocationType_DirPointerArray:      2784 (2 KiB)
AllocationType_DirContextSet:        695280 (678 KiB)
AllocationType_FileContextSet:       9197440 (8981 KiB)
AllocationType_Header:               0 (0 KiB)
===

=== Stats ===
Total Allocated: 26273427 (25657 KiB)
Peak Allocated:  35572244 (34738 KiB)
Total Count: 229937
Peak Count:  741957
==
```

Generated romfs_metadata.bin had 15.8 MB, so I decided to use 16 MB. It seems to boot even with 8 MB, but added something to have a nice buffer.