### PR TITLE
fs.mitm: Added support for `DeviceOperator -> GetGameCardCompatibilityType`, this bypass region lock for terra cards

### DIFF
--- a/stratosphere/ams_mitm/source/fs_mitm/fs_ido_mitm_service.cpp
+++ b/stratosphere/ams_mitm/source/fs_mitm/fs_ido_mitm_service.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Atmosphère-NX
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <stratosphere.hpp>
+#include "../amsmitm_fs_utils.hpp"
+#include "fs_ido_mitm_service.hpp"
+
+namespace ams::mitm::fs {
+    Result FsDoMitmService::GetGameCardCompatibilityType(sf::Out<u8> out, u32 card_handle) {
+        AMS_UNUSED(card_handle);
+
+        out.SetValue(0x00);
+        R_SUCCEED();
+    }
+}

--- a/stratosphere/ams_mitm/source/fs_mitm/fs_ido_mitm_service.hpp
+++ b/stratosphere/ams_mitm/source/fs_mitm/fs_ido_mitm_service.hpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Atmosphère-NX
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+#include <stratosphere.hpp>
+#include <stratosphere/fssrv/fssrv_interface_adapters.hpp>
+
+#define AMS_FS_IDO_MITM_INTERFACE_INFO(C, H) \
+    AMS_SF_METHOD_INFO(C, H, 220, Result, GetGameCardCompatibilityType, (sf::Out<u8> out, u32 card_handle), (out, card_handle), hos::Version_9_0_0)
+
+
+AMS_SF_DEFINE_MITM_INTERFACE(ams::mitm::fs, IDoFsMitmInterface, AMS_FS_IDO_MITM_INTERFACE_INFO, 0x1484E21C)
+
+namespace ams::mitm::fs {
+
+    class FsDoMitmService  : public sf::MitmServiceImplBase {
+        public:
+            using MitmServiceImplBase::MitmServiceImplBase;
+            /* Overridden commands. */
+            Result GetGameCardCompatibilityType(sf::Out<u8> out, u32 card_handle);
+    };
+    static_assert(IsIDoFsMitmInterface<FsDoMitmService>);
+
+}

--- a/stratosphere/ams_mitm/source/fs_mitm/fs_ido_mitm_service.hpp
+++ b/stratosphere/ams_mitm/source/fs_mitm/fs_ido_mitm_service.hpp
@@ -28,6 +28,10 @@ namespace ams::mitm::fs {
     class FsDoMitmService  : public sf::MitmServiceImplBase {
         public:
             using MitmServiceImplBase::MitmServiceImplBase;
+            virtual ~FsDoMitmService() {
+                serviceClose(m_forward_service.get());
+            }
+        public:
             /* Overridden commands. */
             Result GetGameCardCompatibilityType(sf::Out<u8> out, u32 card_handle);
     };

--- a/stratosphere/ams_mitm/source/fs_mitm/fs_mitm_service.cpp
+++ b/stratosphere/ams_mitm/source/fs_mitm/fs_mitm_service.cpp
@@ -370,6 +370,16 @@ namespace ams::mitm::fs {
         R_SUCCEED();
     }
 
+    Result FsMitmService::OpenDeviceOperator(sf::Out<sf::SharedPointer<ams::mitm::fs::IDoFsMitmInterface>> out)
+    {
+        FsDeviceOperator fsIdo;
+        R_TRY(fsOpenDeviceOperatorFwd(m_forward_service.get(), std::addressof(fsIdo)));
+        const sf::cmif::DomainObjectId target_object_id{serviceGetObjectId(std::addressof(fsIdo.s))};
+
+        out.SetValue(sf::CreateSharedObjectEmplaced<ams::mitm::fs::IDoFsMitmInterface, FsDoMitmService>(std::make_shared<::Service>(fsIdo.s), m_client_info), target_object_id);
+        R_SUCCEED();
+    }
+
     Result FsMitmService::RegisterProgramIndexMapInfo(const sf::InBuffer &info_buffer, s32 info_count) {
         /* Try to register with FS. */
         R_TRY(fsRegisterProgramIndexMapInfoFwd(m_forward_service.get(), info_buffer.GetPointer(), info_buffer.GetSize(), info_count));

--- a/stratosphere/ams_mitm/source/fs_mitm/fs_mitm_service.cpp
+++ b/stratosphere/ams_mitm/source/fs_mitm/fs_mitm_service.cpp
@@ -370,8 +370,7 @@ namespace ams::mitm::fs {
         R_SUCCEED();
     }
 
-    Result FsMitmService::OpenDeviceOperator(sf::Out<sf::SharedPointer<ams::mitm::fs::IDoFsMitmInterface>> out)
-    {
+    Result FsMitmService::OpenDeviceOperator(sf::Out<sf::SharedPointer<ams::mitm::fs::IDoFsMitmInterface>> out) {
         FsDeviceOperator fsIdo;
         R_TRY(fsOpenDeviceOperatorFwd(m_forward_service.get(), std::addressof(fsIdo)));
         const sf::cmif::DomainObjectId target_object_id{serviceGetObjectId(std::addressof(fsIdo.s))};

--- a/stratosphere/ams_mitm/source/fs_mitm/fs_mitm_service.hpp
+++ b/stratosphere/ams_mitm/source/fs_mitm/fs_mitm_service.hpp
@@ -46,6 +46,11 @@ namespace ams::mitm::fs {
                     return true;
                 }
 
+                /* We want to mitm loader, to support bypass region lock of terra cards */
+                if (program_id == ncm::SystemProgramId::Loader) {
+                    return true;
+                }
+
                 /* We want to mitm ns, to intercept SD card requests and program index map info registration. */
                 if (program_id == ncm::SystemProgramId::Ns) {
                     return true;

--- a/stratosphere/ams_mitm/source/fs_mitm/fs_mitm_service.hpp
+++ b/stratosphere/ams_mitm/source/fs_mitm/fs_mitm_service.hpp
@@ -17,6 +17,8 @@
 #include <stratosphere.hpp>
 #include <stratosphere/fssrv/fssrv_interface_adapters.hpp>
 
+#include "fs_ido_mitm_service.hpp"
+
 #define AMS_FS_MITM_INTERFACE_INFO(C, H)                                                                                                                                                                                                                                               \
     AMS_SF_METHOD_INFO(C, H,   7, Result, OpenFileSystemWithPatch,         (sf::Out<sf::SharedPointer<ams::fssrv::sf::IFileSystem>> out, ncm::ProgramId program_id, u32 _filesystem_type),                              (out, program_id, _filesystem_type),       hos::Version_2_0_0) \
     AMS_SF_METHOD_INFO(C, H,   8, Result, OpenFileSystemWithId,            (sf::Out<sf::SharedPointer<ams::fssrv::sf::IFileSystem>> out, const fssrv::sf::Path &path, ncm::ProgramId program_id, u32 _filesystem_type), (out, path, program_id, _filesystem_type), hos::Version_2_0_0) \
@@ -26,6 +28,7 @@
     AMS_SF_METHOD_INFO(C, H, 200, Result, OpenDataStorageByCurrentProcess, (sf::Out<sf::SharedPointer<ams::fssrv::sf::IStorage>> out),                                                                                  (out))                                                         \
     AMS_SF_METHOD_INFO(C, H, 202, Result, OpenDataStorageByDataId,         (sf::Out<sf::SharedPointer<ams::fssrv::sf::IStorage>> out, ncm::DataId data_id, u8 storage_id),                                              (out, data_id, storage_id))                                    \
     AMS_SF_METHOD_INFO(C, H, 205, Result, OpenDataStorageWithProgramIndex, (sf::Out<sf::SharedPointer<ams::fssrv::sf::IStorage>> out, u8 program_index),                                                                (out, program_index),                      hos::Version_7_0_0) \
+    AMS_SF_METHOD_INFO(C, H, 400, Result, OpenDeviceOperator,              (sf::Out<sf::SharedPointer<ams::mitm::fs::IDoFsMitmInterface>> out),                                                                              (out))                                                         \
     AMS_SF_METHOD_INFO(C, H, 810, Result, RegisterProgramIndexMapInfo,     (const sf::InBuffer &info_buffer, s32 info_count),                                                                                           (info_buffer, info_count),                 hos::Version_7_0_0)
 
 
@@ -85,6 +88,7 @@ namespace ams::mitm::fs {
             Result OpenDataStorageByCurrentProcess(sf::Out<sf::SharedPointer<ams::fssrv::sf::IStorage>> out);
             Result OpenDataStorageByDataId(sf::Out<sf::SharedPointer<ams::fssrv::sf::IStorage>> out, ncm::DataId data_id, u8 storage_id);
             Result OpenDataStorageWithProgramIndex(sf::Out<sf::SharedPointer<ams::fssrv::sf::IStorage>> out, u8 program_index);
+            Result OpenDeviceOperator(sf::Out<sf::SharedPointer<ams::mitm::fs::IDoFsMitmInterface>> out);
             Result RegisterProgramIndexMapInfo(const sf::InBuffer &info_buffer, s32 info_count);
     };
     static_assert(IsIFsMitmInterface<FsMitmService>);

--- a/stratosphere/ams_mitm/source/fs_mitm/fs_mitm_service.hpp
+++ b/stratosphere/ams_mitm/source/fs_mitm/fs_mitm_service.hpp
@@ -46,11 +46,6 @@ namespace ams::mitm::fs {
                     return true;
                 }
 
-                /* We want to mitm loader, to support bypass region lock of terra cards */
-                if (program_id == ncm::SystemProgramId::Loader) {
-                    return true;
-                }
-
                 /* We want to mitm ns, to intercept SD card requests and program index map info registration. */
                 if (program_id == ncm::SystemProgramId::Ns) {
                     return true;

--- a/stratosphere/ams_mitm/source/fs_mitm/fs_shim.c
+++ b/stratosphere/ams_mitm/source/fs_mitm/fs_shim.c
@@ -103,3 +103,7 @@ Result fsOpenFileSystemWithIdFwd(Service* s, FsFileSystem* out, u64 id, FsFileSy
         .out_objects = &out->s
     );
 }
+
+Result fsOpenDeviceOperatorFwd(Service *s, FsDeviceOperator* out) {
+    return _fsOpenSession(s, &out->s, 400);
+}

--- a/stratosphere/ams_mitm/source/fs_mitm/fs_shim.h
+++ b/stratosphere/ams_mitm/source/fs_mitm/fs_shim.h
@@ -25,6 +25,7 @@ Result fsOpenSaveDataFileSystemFwd(Service* s, FsFileSystem* out, FsSaveDataSpac
 Result fsOpenFileSystemWithPatchFwd(Service* s, FsFileSystem* out, u64 id, FsFileSystemType fsType);
 Result fsOpenFileSystemWithIdFwd(Service* s, FsFileSystem* out, u64 id, FsFileSystemType fsType, const char* contentPath);
 
+Result fsOpenDeviceOperatorFwd(Service *s, FsDeviceOperator* out);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
I have some Terra cards, but I recently sold my Terra console. In order to make these cartridges work on "global" consoles, I looked into the region lock mechanism used by Terra cards.

It turns out that the ns service determines compatibility via GetGameCardCompatibilityType. When the returned CompatibilityType does not match the device region, the system throws an error upon cartridge insertion. By using a mitm approach, this PR forces the fs function to always return 0x00, effectively bypassing the region lock check.

~Additionally, we need to mitm loader to prevent errors during game launch caused by a CompatibilityType mismatch.~

The functionality in this PR has been fully tested across multiple devices. It resolves the issue where Terra cards cannot run on "global" devices, without impacting normal global cartridge functionality.