### PR TITLE
pgl: GetHostContentMetaInfo returns a ncm::ContentMetaType

### DIFF
--- a/libraries/libstratosphere/include/stratosphere/pgl/pgl_types.hpp
+++ b/libraries/libstratosphere/include/stratosphere/pgl/pgl_types.hpp
@@ -41,7 +41,8 @@ namespace ams::pgl {
         u32 version;
         ncm::ContentType content_type;
         u8 id_offset;
-        u8 reserved_0E[2];
+        ncm::ContentMetaType content_meta_type;
+        u8 reserved_0F;
 
         static constexpr ContentMetaInfo Make(u64 id, u32 version, ncm::ContentType content_type, u8 id_offset) {
             return {

--- a/libraries/libstratosphere/source/pgl/srv/pgl_srv_shell_host_utils.cpp
+++ b/libraries/libstratosphere/source/pgl/srv/pgl_srv_shell_host_utils.cpp
@@ -345,10 +345,11 @@ namespace ams::pgl::srv {
 
         /* Get the content meta info. */
         *out = {
-            .id           = reader.GetProgramId().value,
-            .version      = reader.GetProgramVersion(),
-            .content_type = ncm::ContentType::Program,
-            .id_offset    = reader.GetProgramIndex(),
+            .id                = reader.GetProgramId().value,
+            .version           = reader.GetProgramVersion(),
+            .content_type      = ncm::ContentType::Program,
+            .id_offset         = reader.GetProgramIndex(),
+            .content_meta_type = reader.GetContentMetaType(),
         };
 
         R_SUCCEED();


### PR DESCRIPTION
This has been the case since pgl was introduced in 10.0.0