### PR TITLE
sf: close request copy handles in mitm ForwardRequest

### DIFF
--- a/libraries/libstratosphere/source/sf/hipc/sf_hipc_server_session_manager.cpp
+++ b/libraries/libstratosphere/source/sf/hipc/sf_hipc_server_session_manager.cpp
@@ -60,7 +60,16 @@ namespace ams::sf::hipc {
         PreProcessCommandBufferForMitm(ctx, m_pointer_buffer, reinterpret_cast<uintptr_t>(message_buffer));
 
         /* Dispatch forwards. */
-        R_TRY(svc::SendSyncRequest(util::GetReference(m_forward_service)->session));
+        {
+            ON_SCOPE_EXIT {
+                const auto saved_request = hipcParseRequest(const_cast<void *>(m_saved_message.GetPointer()));
+                for (u32 i = 0; i < saved_request.meta.num_copy_handles; i++) {
+                    os::CloseNativeHandle(saved_request.data.copy_handles[i]);
+                }
+            };
+
+            R_TRY(svc::SendSyncRequest(util::GetReference(m_forward_service)->session));
+        }
 
         /* Parse, to ensure we catch any copy handles and close them. */
         {


### PR DESCRIPTION
ForwardRequest closes copy handles from the forward response but never from the request. Any mitm'd command that carries a client copy handle therefore leaks that handle in the mitm process for its lifetime. A leaked transfer memory pins the client process object after it dies, its application memory reservation never releases, and the next application launch blocks forever freezing the console.

Close the request's copy handles after the forward send, parsed from the saved message.