### PR TITLE
Upgrade Scripts for Python 3.x

### DIFF
--- a/fusee/program/update_mtc_tables.py
+++ b/fusee/program/update_mtc_tables.py
@@ -43,10 +43,10 @@ def main(argc, argv):
             assert board.startswith('T210Sdev')
             soc = 'erista'
             count = 10
-        assert os.listdir('mtc_tables/bin/%s' % board) == ['%d.bin' % i for i in xrange(count)]
+        assert os.listdir('mtc_tables/bin/%s' % board) == ['%d.bin' % i for i in range(count)]
         params[soc][board] = []
         compressed_params[soc][board] = []
-        for i in xrange(count):
+        for i in range(count):
             uncompressed = read_file(os.path.join('mtc_tables/bin/%s' % board, '%d.bin' % i))
             assert len(uncompressed) == get_param_size(soc)
             compressed = lz4_compress(uncompressed)

--- a/fusee/program/update_sdram_params.py
+++ b/fusee/program/update_sdram_params.py
@@ -45,7 +45,7 @@ def main(argc, argv):
         params[soc][param_id] = uncompressed
     for soc in ('erista', 'mariko'):
         empty_params = '\x00' * get_param_size(soc)
-        for param_id in xrange(0, max(params[soc].keys()) + 4, 2):
+        for param_id in range(0, max(params[soc].keys()) + 4, 2):
             param_id_l = param_id
             param_id_h = param_id + 1
             if param_id_l in params[soc] or param_id_h in params[soc]:

--- a/utilities/erpt.py
+++ b/utilities/erpt.py
@@ -51,7 +51,7 @@ if sys.version_info[0] == 3:
     bytes_to_list = lambda b: list(b)
     list_to_bytes = lambda l: bytes(l)
 else:
-    iter_range = xrange
+    iter_range = range
     int_types = (int, long)
     ascii_string = lambda b: str(b)
     bytes_to_list = lambda b: map(ord, b)
@@ -471,7 +471,7 @@ def main(argc, argv):
     if argc == 3:
         mf, mc, mt, ml = (64, 48, 32, 32)
     format_string = '- %%-%ds %%-%ds %%-%ds %%-%ds' % (mf+1, mc+1, mt+1, ml)
-    for i in xrange(NUM_FIELDS):
+    for i in range(NUM_FIELDS):
         f, c, t, l = fields[i], cat_to_string(cats[i]), typ_to_string(types[i]), flg_to_string(flags[i])
         print format_string % (f+',', c+',', t+',', l)
     with open(argv[-1]+'.hpp', 'w') as out:
@@ -485,7 +485,7 @@ def main(argc, argv):
             out.write(('    HANDLER(%%-%ds %%-3d) \\\n' % (mc+1)) % (cat_to_string(ct)+',', ct))
         out.write('\n')
         out.write('#define AMS_ERPT_FOREACH_FIELD(HANDLER) \\\n')
-        for i in xrange(NUM_FIELDS):
+        for i in range(NUM_FIELDS):
             f, c, t, l, d = fields[i], cats[i], types[i], flags[i], ids[i]
             out.write(('    HANDLER(%%-%ds %%-4s %%-%ds %%-%ds %%-%ds) \\\n' % (mf+1, mc+1, mt+1, ml)) % (f+',', '%d,'%d, cat_to_string(c)+',', typ_to_string(t)+',', flg_to_string(l)))
         out.write('\n')

--- a/utilities/nxo64.py
+++ b/utilities/nxo64.py
@@ -86,7 +86,7 @@ class BinFile(object):
 (DT_NULL, DT_NEEDED, DT_PLTRELSZ, DT_PLTGOT, DT_HASH, DT_STRTAB, DT_SYMTAB, DT_RELA, DT_RELASZ,
  DT_RELAENT, DT_STRSZ, DT_SYMENT, DT_INIT, DT_FINI, DT_SONAME, DT_RPATH, DT_SYMBOLIC, DT_REL,
  DT_RELSZ, DT_RELENT, DT_PLTREL, DT_DEBUG, DT_TEXTREL, DT_JMPREL, DT_BIND_NOW, DT_INIT_ARRAY,
- DT_FINI_ARRAY, DT_INIT_ARRAYSZ, DT_FINI_ARRAYSZ, DT_RUNPATH, DT_FLAGS) = xrange(31)
+ DT_FINI_ARRAY, DT_INIT_ARRAYSZ, DT_FINI_ARRAYSZ, DT_RUNPATH, DT_FLAGS) = range(31)
 
 DT_RELRSZ, DT_RELR, DT_RELRENT = 0x23, 0x24, 0x25
 
@@ -265,7 +265,7 @@ class NxoFileBase(object):
         self.dynamic = dynamic = {}
         for i in MULTIPLE_DTS:
             dynamic[i] = []
-        for i in xrange((f.size() - self.dynamicoff) / 0x10):
+        for i in range((f.size() - self.dynamicoff) / 0x10):
             tag, val = f.read('II' if self.armv7 else 'QQ')
             if tag == DT_NULL:
                 break
@@ -517,7 +517,7 @@ class NxoFileBase(object):
         locations = set()
         f.seek(offset)
         relocsize = 8 if self.armv7 else 0x18
-        for i in xrange(size / relocsize):
+        for i in range(size / relocsize):
             # NOTE: currently assumes all armv7 relocs have no addends,
             # and all 64-bit ones do.
             if self.armv7:
@@ -541,7 +541,7 @@ class NxoFileBase(object):
         locations = set()
         f.seek(offset)
         relocsize = 8
-        for i in xrange(size / relocsize):
+        for i in range(size / relocsize):
             entry = f.read('Q')
             if entry & 1:
                 entry >>= 1
@@ -661,7 +661,7 @@ def kip1_blz_decompress(compressed):
     while out_ofs > 0:
         cmp_ofs -= 1
         control = decompressed[cmp_start + cmp_ofs]
-        for i in xrange(8):
+        for i in range(8):
             if control & 0x80:
                 if cmp_ofs < 2 - cmp_start:
                     raise ValueError('Compression out of bounds!')
@@ -672,7 +672,7 @@ def kip1_blz_decompress(compressed):
                 segmentoffset += 2
                 if out_ofs < segmentsize - cmp_start:
                     raise ValueError('Compression out of bounds!')
-                for j in xrange(segmentsize):
+                for j in range(segmentsize):
                     if out_ofs + segmentoffset >= decompressed_size:
                         raise ValueError('Compression out of bounds!')
                     data = decompressed[cmp_start + out_ofs + segmentoffset]
@@ -878,7 +878,7 @@ else:
 
     def find_bl_targets(text_start, text_end):
         targets = set()
-        for pco in xrange(0, text_end - text_start, 4):
+        for pco in range(0, text_end - text_start, 4):
             pc = text_start + pco
             d = Dword(pc)
             if (d & 0xfc000000) == 0x94000000:
@@ -1052,7 +1052,7 @@ else:
 
             if bypass_plt:
                 plt_lookup = f.plt_lookup
-                for pco in xrange(0, f.textsize, 4):
+                for pco in range(0, f.textsize, 4):
                     pc = loadbase + pco
                     d = Dword(pc)
                     if (d & 0x7c000000) == (0x94000000 & 0x7c000000):
@@ -1067,7 +1067,7 @@ else:
                             new_instr = (d & ~0x3ffffff) | (((new_target - pc) / 4) & 0x3ffffff)
                             idaapi.put_long(pc, new_instr)
 
-            for pco in xrange(0, f.textsize, 4):
+            for pco in range(0, f.textsize, 4):
                 pc = loadbase + pco
                 d = Dword(pc)
                 if d == 0x14000001:


### PR DESCRIPTION
Upgrade of the scripts 
* utilities\erpt.py
* utilities\nxo64.py
* fusee\program\update_mtc_tables.py
* fusee\program\update_sdram_params.py

to replace the deprecated and removed function `xrange` for the function `range` which is on Python 3 and onward