### PR TITLE
RO exception offsets are signed

### DIFF
--- a/libraries/libmesosphere/source/arch/arm64/kern_k_debug.cpp
+++ b/libraries/libmesosphere/source/arch/arm64/kern_k_debug.cpp
@@ -25,8 +25,8 @@ namespace ams::rocrt {
         u32 dynamic_offset;
         u32 bss_start_offset;
         u32 bss_end_offset;
-        u32 exception_info_start_offset;
-        u32 exception_info_end_offset;
+        s32 exception_info_start_offset;
+        s32 exception_info_end_offset;
         u32 module_offset;
     };
 

--- a/libraries/libstratosphere/include/stratosphere/rocrt/rocrt.hpp
+++ b/libraries/libstratosphere/include/stratosphere/rocrt/rocrt.hpp
@@ -26,8 +26,8 @@ namespace ams::rocrt {
         u32 dynamic_offset;
         u32 bss_start_offset;
         u32 bss_end_offset;
-        u32 exception_info_start_offset;
-        u32 exception_info_end_offset;
+        s32 exception_info_start_offset;
+        s32 exception_info_end_offset;
         u32 module_offset;
     };
 


### PR DESCRIPTION
Assassin's Crees 3 NROs have .eh_frame_hdr above MOD0 which proves that those are signed. I couldn't load NRO to IDA with TSRBerry's nxo64 which also uses unsigned offsets so i sent PR to TSRBerry fork that fixes this issue and NRO loads correctly.